### PR TITLE
fix the zsh startup file reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Eventually, you'll be able to manage all your Rubies, tools, gems, and packages,
 
 ```bash
 brew install spinel-coop/tap/rv
-echo 'eval "$(rv shell init zsh)"' >> ~/.zshrc
+echo 'eval "$(rv shell init zsh)"' >> ${ZDOTDIR:-$HOME}/.zshrc
 eval "$(rv shell init zsh)"
 ```
 


### PR DESCRIPTION
`~/.zshrc` is of course very common but it isn't used universally.  However `$ZDOTDIR` should reliably get the location of the file if it is not `$HOME`.

Reference: https://zsh.sourceforge.io/Intro/intro_3.html

