### PR TITLE
Fix `rv ruby pin` if not run in a project_dir

### DIFF
--- a/crates/rv/src/commands/ruby/pin.rs
+++ b/crates/rv/src/commands/ruby/pin.rs
@@ -22,11 +22,11 @@ pub fn pin(config: &Config, version: Option<String>) -> Result<()> {
 }
 
 fn set_pinned_ruby(config: &Config, version: String) -> Result<()> {
-    let project_dir = config.project_dir.as_ref().ok_or_else(|| {
-        Error::ConfigError(config::Error::NoProjectDir {
-            current_dir: config.current_dir.clone(),
-        })
-    })?;
+    let project_dir = config
+        .project_dir
+        .as_ref()
+        .unwrap_or(&config.current_dir);
+
     let ruby_version_path = project_dir.join(".ruby-version");
     std::fs::write(ruby_version_path, format!("{version}\n"))?;
 
@@ -36,7 +36,12 @@ fn set_pinned_ruby(config: &Config, version: String) -> Result<()> {
 }
 
 fn show_pinned_ruby(config: &Config) -> Result<()> {
-    let path = config.project_dir.as_ref().unwrap().join(".ruby-version");
+    let project_dir = config.project_dir.as_ref().ok_or_else(|| {
+        Error::ConfigError(config::Error::NoProjectDir {
+            current_dir: config.current_dir.clone(),
+        })
+    })?;
+    let path = project_dir.join(".ruby-version");
     let ruby_version = std::fs::read_to_string(path)?;
 
     println!(

--- a/crates/rv/src/commands/ruby/pin.rs
+++ b/crates/rv/src/commands/ruby/pin.rs
@@ -22,10 +22,7 @@ pub fn pin(config: &Config, version: Option<String>) -> Result<()> {
 }
 
 fn set_pinned_ruby(config: &Config, version: String) -> Result<()> {
-    let project_dir = config
-        .project_dir
-        .as_ref()
-        .unwrap_or(&config.current_dir);
+    let project_dir = config.project_dir.as_ref().unwrap_or(&config.current_dir);
 
     let ruby_version_path = project_dir.join(".ruby-version");
     std::fs::write(ruby_version_path, format!("{version}\n"))?;

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -8,6 +8,7 @@ use rv_cache::CacheArgs;
 use tokio::main;
 use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+use miette::Report;
 
 pub mod commands;
 pub mod config;
@@ -194,7 +195,14 @@ pub enum Error {
 type Result<T> = miette::Result<T, Error>;
 
 #[main]
-async fn main() -> Result<()> {
+async fn main() {
+    if let Err(err) = run().await {
+        eprintln!("{:?}", Report::new(err));
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     let indicatif_layer = IndicatifLayer::new();

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -4,11 +4,11 @@ use clap::builder::Styles;
 use clap::builder::styling::AnsiColor;
 use clap::{Parser, Subcommand};
 use config::Config;
+use miette::Report;
 use rv_cache::CacheArgs;
 use tokio::main;
 use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
-use miette::Report;
 
 pub mod commands;
 pub mod config;

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -197,7 +197,12 @@ type Result<T> = miette::Result<T, Error>;
 #[main]
 async fn main() {
     if let Err(err) = run().await {
-        eprintln!("{:?}", Report::new(err));
+        let is_tty = std::io::stderr().is_terminal();
+        if is_tty {
+            eprintln!("{:?}", Report::new(err));
+        } else {
+            eprintln!("Error: {:?}", err);
+        }
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
If you run `rv ruby pin` in a directory which is not a project directory (contains a `.ruby-version`), then `rv` would segfault:

```
thread 'main' panicked at crates/rv/src/commands/ruby/pin.rs:39:44:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This patch fixes the segfault and prints a proper error message:

```
  × No project was found in the parents of /home/coezbek/2025/rvtest
```

It also updates `rv ruby pin $version` to create a `.ruby-version` in the current directory if no project_dir is found.