### PR TITLE
turn up LTO for smaller releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,5 @@ rv-version = { version = "0.1.0", path = "crates/rv-version" }
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+codegen-units = 1
+lto = true


### PR DESCRIPTION
As suggested in #48, and reproduced by me. Binary size dropped from 9.9mb to 5.6mb, build time increased from 24s to 57s.

Since this higher build time only applies to release builds and not CI test builds, I think this is a great improvement.
