### PR TITLE
Implement fish as a supported shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ eval "$(rv shell init zsh)"
 # bash
 echo 'eval "$(rv shell init bash)"' >> ~/.bashrc
 eval "$(rv shell init bash)"
+# fish
+echo 'rv shell init fish | source' >> ~/.config/fish/config.fish
+rv shell init fish | source
 ```
 
 ## Usage

--- a/crates/rv/src/commands/shell.rs
+++ b/crates/rv/src/commands/shell.rs
@@ -14,12 +14,12 @@ pub struct ShellArgs {
 pub enum ShellCommand {
     #[command(about = "Configure your shell to use rv")]
     Init {
-        /// The shell to initialize (only zsh and bash so far)
+        /// The shell to initialize (zsh, bash and fish so far)
         shell: Shell,
     },
     #[command(hide = true)]
     Env {
-        /// The shell to configure (only zsh and bash so far)
+        /// The shell to configure (zsh, bash and fish so far)
         shell: Shell,
     },
 }
@@ -29,4 +29,5 @@ pub enum Shell {
     #[default]
     Zsh,
     Bash,
+    Fish,
 }

--- a/crates/rv/src/commands/shell/env.rs
+++ b/crates/rv/src/commands/shell/env.rs
@@ -30,5 +30,14 @@ pub fn env(config: &config::Config, shell: Shell) -> Result<()> {
             println!("hash -r");
             Ok(())
         }
+        Shell::Fish => {
+            if !unset.is_empty() {
+                println!("set -ge {}", unset.join(" "))
+            }
+            for (var, val) in set {
+                println!("set -gx {var} {}", shell_escape::escape(val.into()))
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/rv/src/commands/shell/env.rs
+++ b/crates/rv/src/commands/shell/env.rs
@@ -35,9 +35,23 @@ pub fn env(config: &config::Config, shell: Shell) -> Result<()> {
                 println!("set -ge {}", unset.join(" "))
             }
             for (var, val) in set {
-                println!("set -gx {var} {}", shell_escape::escape(val.into()))
+                println!("set -gx {var} \"{}\"", backslack_escape(val))
             }
             Ok(())
         }
     }
+}
+
+// From uv's crates/uv-shell/src/lib.rs
+// Assumes strings will be outputed as "str", so escapes any \ or " character
+fn backslack_escape(s: String) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' | '"' => escaped.push('\\'),
+            _ => {}
+        }
+        escaped.push(c)
+    }
+    escaped
 }

--- a/crates/rv/src/commands/shell/init.rs
+++ b/crates/rv/src/commands/shell/init.rs
@@ -45,5 +45,17 @@ pub fn init(config: &Config, shell: Shell) -> Result<()> {
             );
             Ok(())
         }
+        Shell::Fish => {
+            print!(
+                concat!(
+                    "function _rv_autoload_hook --on-variable PWD --description 'Change Ruby version on directory change using rv'\n",
+                    "    status --is-command-substitution; and return\n",
+                    "    {} shell env fish | source\n",
+                    "end\n"
+                ),
+                config.current_exe
+            );
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
This is an attempt at fixing #55, as suggested, inspired by how `frum` seems to implement fish.

I tested and it seems to work here locally, would love a second look to verify I didn't forget anything :)