### PR TITLE
add support for fish

### DIFF
--- a/crates/rv/src/commands/shell.rs
+++ b/crates/rv/src/commands/shell.rs
@@ -29,4 +29,5 @@ pub enum Shell {
     #[default]
     Zsh,
     Bash,
+    Fish,
 }

--- a/crates/rv/src/commands/shell/env.rs
+++ b/crates/rv/src/commands/shell/env.rs
@@ -30,5 +30,16 @@ pub fn env(config: &config::Config, shell: Shell) -> Result<()> {
             println!("hash -r");
             Ok(())
         }
+        Shell::Fish => {
+            if !unset.is_empty() {
+                println!("set --erase {}", unset.join(" "));
+            }
+
+            for (var, val) in set {
+                println!("set --export {var} {}", shell_escape::escape(val.into()))
+            }
+
+            Ok(())
+        }
     }
 }

--- a/crates/rv/src/commands/shell/init.rs
+++ b/crates/rv/src/commands/shell/init.rs
@@ -45,5 +45,17 @@ pub fn init(config: &Config, shell: Shell) -> Result<()> {
             );
             Ok(())
         }
+        Shell::Fish => {
+            print!(
+                concat!(
+                    "function _rv_autoload_hook --on-variable PWD\n",
+                    "    \"{}\" shell env fish | source\n",
+                    "end\n",
+                    "_rv_autoload_hook\n"
+                ),
+                config.current_exe
+            );
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
Heya! Thanks for making `rv`, it's always nice to see crossover between the Ruby and Rust communities.

This is a small addition to address #55, since `fish` is my preferred shell.

The implementation is entirely based on the `zsh` version. The differences are mostly just syntax, since all the shell integrations really need to do is configure environment variables, and all the heavy lifting is done elsewhere. 😅

Tested with `fish` v4.0.2.

If there's anything I missed, just let me know and I'll try to fix it. 😉 

Thanks again for making something cool! ❤️ 