### PR TITLE
Add `rv shell completions [fish,bash,zsh]`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +1902,7 @@ dependencies = [
  "camino-tempfile-ext",
  "clap",
  "clap-verbosity-flag",
+ "clap_complete",
  "clap_derive",
  "current_platform",
  "etcetera",

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -48,6 +48,7 @@ bytesize = { workspace = true }
 shell-escape = { workspace = true }
 lazy_static = { workspace = true }
 rayon-tracing = { workspace = true }
+clap_complete = "4.5.57"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/rv/src/commands/shell.rs
+++ b/crates/rv/src/commands/shell.rs
@@ -1,3 +1,4 @@
+pub mod completions;
 pub mod env;
 pub mod init;
 
@@ -15,6 +16,11 @@ pub enum ShellCommand {
     #[command(about = "Configure your shell to use rv")]
     Init {
         /// The shell to initialize (zsh, bash and fish so far)
+        shell: Shell,
+    },
+    #[command()]
+    Completions {
+        /// The shell to print completions for (zsh, bash and fish so far)
         shell: Shell,
     },
     #[command(hide = true)]

--- a/crates/rv/src/commands/shell/completions.rs
+++ b/crates/rv/src/commands/shell/completions.rs
@@ -1,0 +1,21 @@
+use std::io::stdout;
+
+use clap_complete::{Shell as ClapCompleteShell, generate};
+
+use super::Shell;
+
+impl From<Shell> for ClapCompleteShell {
+    fn from(shell: Shell) -> Self {
+        match shell {
+            Shell::Zsh => ClapCompleteShell::Zsh,
+            Shell::Bash => ClapCompleteShell::Bash,
+            Shell::Fish => ClapCompleteShell::Fish,
+        }
+    }
+}
+
+pub fn shell_completions(cmd: &mut clap::Command, shell: Shell) {
+    let clap_complete_shell: ClapCompleteShell = shell.into();
+    let name = cmd.get_name().to_owned();
+    generate(clap_complete_shell, cmd, name, &mut stdout());
+}

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -2,7 +2,7 @@ use anstream::stream::IsTerminal;
 use camino::{FromPathBufError, Utf8PathBuf};
 use clap::builder::Styles;
 use clap::builder::styling::AnsiColor;
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{ArgAction, CommandFactory, Parser, Subcommand};
 use config::Config;
 use miette::Report;
 use rv_cache::CacheArgs;
@@ -21,6 +21,7 @@ use crate::commands::ruby::pin::pin as ruby_pin;
 #[cfg(unix)]
 use crate::commands::ruby::run::run as ruby_run;
 use crate::commands::ruby::{RubyArgs, RubyCommand};
+use crate::commands::shell::completions::shell_completions;
 use crate::commands::shell::env::env as shell_env;
 use crate::commands::shell::init::init as shell_init;
 use crate::commands::shell::{ShellArgs, ShellCommand};
@@ -287,6 +288,9 @@ async fn run() -> Result<()> {
             },
             Commands::Shell(shell) => match shell.command {
                 ShellCommand::Init { shell } => shell_init(&config, shell)?,
+                ShellCommand::Completions { shell } => {
+                    shell_completions(&mut Cli::command(), shell)
+                }
                 ShellCommand::Env { shell } => shell_env(&config, shell)?,
             },
         },


### PR DESCRIPTION
In particular, this allows completions to be automatically installed using Homebrew: https://github.com/Homebrew/homebrew-core/compare/main...lgarron:homebrew-core:rv-shell-completions
```diff
+    generate_completions_from_executable(bin/"rv", "shell", "completions")
```

Note that this is called `completions` rather than `complete` because the latter would make more sense for a dynamic completion provider (which is possible but not really necessary at the moment).

Also note that the same set of shells are supported as in the other `rv shell` commands. It would be easy instead to support to support [all shells handled by `clap_complete`](https://docs.rs/clap_complete/latest/clap_complete/aot/enum.Shell.html), but the inconsistency could cause surprises.

Test locally using:

```shell
mkdir -p ~/.config/fish/completions
cargo run -- shell completions fish > ~/.config/fish/completions/rv.fish

# Load any new `fish` shell to pick up the completions.
fish
```