### PR TITLE
Observe the XDG directory conventions for the `rubies` path.

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -127,9 +127,9 @@ Finally, the ruby version can also be provided by `rbproject.kdl`, although tool
 
 ## ruby locations
 
-By default, we look for rubies in ~/.rubies, /opt/rubies, /opt/homebrew/bin/ruby, /usr/bin/ruby, and /usr/local/bin/ruby.
+By default, we look for rubies in `$XDG_DATA_HOME/rv/rubies`, `~/.data/rv/rubies`, `~/.rubies`, `/opt/rubies`, `/usr/local/rubies`.
 
-By default, we install rubies into ~/.rubies.
+By default, we install rubies into `~/.data/rv/rubies`.
 
 ## `run` vs `exec`
 


### PR DESCRIPTION
This will resolve to `$XDG_DATA_HOME/rv/rubies` if `$XDG_DATA_HOME` is set, or `~/.local/share/rv/rubies` by default.

The legacy path of `~/.rubies` is treated as the first fallback, although it seems the fallback code has a pre-existing bug that prevents this from working.

Fixes: https://github.com/spinel-coop/rv/issues/83