### PR TITLE
Clean up files if download fails

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -57,7 +57,11 @@ pub async fn install(
             tarball_path.cyan()
         );
     } else {
-        download_ruby_tarball(&url, &tarball_path).await?;
+        download_ruby_tarball(&url, &tarball_path)
+            .await
+            .inspect_err(|_| {
+                let _ = std::fs::remove_file(&tarball_path);
+            })?;
     }
 
     extract_ruby_tarball(&tarball_path, &install_dir).await?;


### PR DESCRIPTION
When a Ruby download fails, an empty file stays in the cache.
This causes future downloads to fail because the empty file is used.
Clearing the cache solves it, but it would be nicer if empty files were never cached.

```bash
❯ bin/rv ruby install 3.3.1
+ cargo run -- ruby install 3.3.1
   Compiling rv v0.1.1 (/home/toma/.workspace/github.com/spinel-coop/rv/crates/rv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.54s
     Running `target/debug/rv ruby install 3.3.1`
  × Download from URL https://github.com/spinel-coop/rv-ruby/releases/download/3.3.1/portable-ruby-3.3.1.x86_64_linux.bottle.tar.gz
  │ failed with status code 404 Not Found

❯ file /home/toma/.cache/rv/ruby-v0/tarballs/b6e3617a94981c77.tar.gz
/home/toma/.cache/rv/ruby-v0/tarballs/b6e3617a94981c77.tar.gz: empty

❯ bin/rv ruby install 3.3.1
+ cargo run -- ruby install 3.3.1
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/rv ruby install 3.3.1`
Tarball /home/toma/.cache/rv/ruby-v0/tarballs/b6e3617a94981c77.tar.gz already exists, skipping download.
  × unexpected end of file
```
