### PR TITLE
remove tiny onboarding speed bump

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -42,13 +42,13 @@ else
 fi
 
 if [[ -z $(which cargo-nextest) ]]; then
-  cargo binstall cargo-nextest
+  cargo binstall cargo-nextest -y
 fi
 
 if [[ -z $(which cargo-insta) ]]; then
-  cargo binstall cargo-insta
+  cargo binstall cargo-insta -y
 fi
 
 if [[ -z $(which dist) ]]; then
-  cargo binstall cargo-dist
+  cargo binstall cargo-dist -y
 fi

--- a/bin/setup
+++ b/bin/setup
@@ -15,7 +15,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   fi
 
   if [[ -z $(which cargo-binstall) ]]; then
-    brew install cargo-binstall -y
+    brew install cargo-binstall
   fi
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
   SUDO=""
@@ -42,13 +42,13 @@ else
 fi
 
 if [[ -z $(which cargo-nextest) ]]; then
-  cargo binstall cargo-nextest -y
+  cargo binstall cargo-nextest
 fi
 
 if [[ -z $(which cargo-insta) ]]; then
-  cargo binstall cargo-insta -y
+  cargo binstall cargo-insta
 fi
 
 if [[ -z $(which dist) ]]; then
-  cargo binstall cargo-dist -y
+  cargo binstall cargo-dist
 fi


### PR DESCRIPTION
if you do `brew install anything -y` you'll get `Error: invalid option: -y`