### PR TITLE
CI: Use nextest instead of cargo-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         components: rustfmt, clippy
 
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
 
@@ -31,7 +34,7 @@ jobs:
       run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: Run tests
-      run: cargo test --all-features
+      run: cargo nextest run --all-features
 
   build:
     name: Build


### PR DESCRIPTION
Nextest is faster than cargo test, and it's already used in `bin/test` so it doesn't really add any complexity to use it in CI too. Plus later down the line, it enables nice features like sharing across multiple CI runners.

Here's a measurement from my Macbook Pro (M2 Pro)

Baseline `cargo test`
real    18.27s
user    111.01s
sys     17.01s
maxmem  442256k

Using `cargo nextest`
real    13.82s
user    113.87s
sys     16.33s
maxmem  442784k