### PR TITLE
nit: Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,13 +1946,11 @@ dependencies = [
  "camino",
  "clap",
  "fs-err",
- "rustc-hash",
  "rv-dirs",
  "seahash",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
  "tracing",
 ]
 
@@ -2003,10 +2001,8 @@ dependencies = [
 name = "rv-gem-types"
 version = "0.1.0"
 dependencies = [
- "either",
  "indexmap 2.10.0",
  "insta",
- "miette",
  "once_cell",
  "regex",
  "rv-version",
@@ -2017,9 +2013,7 @@ dependencies = [
 name = "rv-ruby"
 version = "0.1.0"
 dependencies = [
- "assert_fs",
  "camino",
- "regex",
  "rv-cache",
  "serde",
  "serde_with",
@@ -2031,7 +2025,6 @@ dependencies = [
 name = "rv-version"
 version = "0.1.0"
 dependencies = [
- "regex",
  "thiserror",
 ]
 

--- a/crates/rv-cache/Cargo.toml
+++ b/crates/rv-cache/Cargo.toml
@@ -7,12 +7,10 @@ edition = "2024"
 camino = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 fs-err = { workspace = true }
-rustc-hash = { workspace = true }
 rv-dirs = { workspace = true }
 seahash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tempfile = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rv-gem-types/Cargo.toml
+++ b/crates/rv-gem-types/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-miette = { workspace = true }
-either = { workspace = true }
 thiserror = { workspace = true }
 regex = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/rv-ruby/Cargo.toml
+++ b/crates/rv-ruby/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-assert_fs = { workspace = true }
 camino = { workspace = true, features = ["serde", "serde1"] }
-regex = { workspace = true }
 rv-cache = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }

--- a/crates/rv-version/Cargo.toml
+++ b/crates/rv-version/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-regex = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
A lot of the crates declared deps they didn't actually use.

But they're still used in other crates, so this doesn't actually remove them from the overall project deps.

I found these vía cargo udeps.