### PR TITLE
Faster RubyRequest operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +287,33 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -402,6 +441,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +497,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -804,6 +882,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1206,6 +1294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1583,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2014,6 +2145,7 @@ name = "rv-ruby"
 version = "0.1.0"
 dependencies = [
  "camino",
+ "criterion",
  "rv-cache",
  "serde",
  "serde_with",
@@ -2465,6 +2597,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,7 @@ rv-version = { version = "0.1.0", path = "crates/rv-version" }
 inherits = "release"
 codegen-units = 1
 lto = true
+
+# The profile that benchmarks, and `cargo-flamegraph` will build with
+[profile.bench]
+debug = true

--- a/crates/rv-ruby/Cargo.toml
+++ b/crates/rv-ruby/Cargo.toml
@@ -10,3 +10,10 @@ serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+criterion = "0.7.0"
+
+[[bench]]
+name = "my_bench"
+harness = false

--- a/crates/rv-ruby/benches/my_bench.rs
+++ b/crates/rv-ruby/benches/my_bench.rs
@@ -1,0 +1,34 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use rv_ruby::request::RubyRequest;
+
+fn parse_ruby_req(c: &mut Criterion) {
+    let req = "3.4.1".to_owned();
+    c.bench_function(&format!("parse {req} into RubyRequest"), |b| {
+        b.iter(|| {
+            let _req: RubyRequest = black_box(req.parse().unwrap());
+        })
+    });
+}
+
+fn ruby_req_to_string(c: &mut Criterion) {
+    let req: RubyRequest = "3.4.1".parse().unwrap();
+    c.bench_function(&format!("Call \"{req}\".to_string()"), |b| {
+        b.iter(|| {
+            let _req = black_box(req.to_string());
+        })
+    });
+}
+
+fn ruby_req_number(c: &mut Criterion) {
+    let req: RubyRequest = "3.4.1".parse().unwrap();
+    c.bench_function(&format!("Call {req}.number()"), |b| {
+        b.iter(|| {
+            let _req = black_box(req.number());
+        })
+    });
+}
+
+criterion_group!(benches, parse_ruby_req, ruby_req_to_string, ruby_req_number);
+criterion_main!(benches);

--- a/crates/rv-ruby/src/request.rs
+++ b/crates/rv-ruby/src/request.rs
@@ -27,6 +27,7 @@ pub enum RequestError {
     #[error("Could not parse {0}: {1}")]
     InvalidPart(&'static str, String),
 }
+
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum MatchError {
     #[error("Ruby version {0} could not be found")]

--- a/crates/rv-ruby/src/request.rs
+++ b/crates/rv-ruby/src/request.rs
@@ -81,21 +81,23 @@ impl RubyRequest {
     }
 
     pub fn number(&self) -> String {
+        use std::fmt::Write;
         let mut version = String::new();
+
         if let Some(major) = self.major {
-            version.push_str(&major.to_string());
+            write!(&mut version, "{}", major).unwrap();
         }
         if let Some(minor) = self.minor {
             version.push('.');
-            version.push_str(&minor.to_string());
+            write!(&mut version, "{}", minor).unwrap();
         }
         if let Some(patch) = self.patch {
             version.push('.');
-            version.push_str(&patch.to_string());
+            write!(&mut version, "{}", patch).unwrap();
         }
         if let Some(tiny) = self.tiny {
             version.push('.');
-            version.push_str(&tiny.to_string());
+            write!(&mut version, "{}", tiny).unwrap();
         }
         if let Some(ref prerelease) = self.prerelease {
             if self.major.is_some() {
@@ -117,77 +119,74 @@ impl FromStr for RubyRequest {
         } else {
             ("ruby", input)
         };
-        let mut segments: Vec<String> = vec![];
+        let mut segments: Option<_> = None;
         let mut prerelease = None;
 
         let first_char = version.chars().next();
         if let Some(first_char) = first_char {
             let (numbers, pre) = if first_char.is_alphabetic() {
                 if version == "dev" {
-                    (None, Some(version.to_string()))
+                    (None, Some(version))
                 } else {
                     Err(RequestError::InvalidVersion(input.to_string()))?
                 }
             } else if let Some(pos) = version.find('-') {
-                (
-                    Some(version[..pos].to_string()),
-                    Some(version[pos + 1..].to_string()),
-                )
+                (Some(&version[..pos]), Some(&version[pos + 1..]))
             } else {
-                (Some(version.to_string()), None)
+                (Some(version), None)
             };
 
-            segments = if let Some(rest) = numbers {
-                rest.split('.')
-                    .map(|s| s.to_string())
-                    .collect::<Vec<String>>()
-            } else {
-                vec![]
-            };
-
-            if segments.len() > 4 {
-                return Err(RequestError::TooManySegments(input.to_string()));
-            }
-
+            segments = numbers.map(|rest| rest.split('.'));
             prerelease = pre;
         };
 
-        let major = if !segments.is_empty() {
-            Some(
-                segments[0]
-                    .parse::<u32>()
-                    .map_err(|_| RequestError::InvalidPart("major version", input.to_string()))?,
-            )
-        } else {
-            None
+        let Some(mut segments) = segments else {
+            return Ok(RubyRequest {
+                engine: engine.into(),
+                major: None,
+                minor: None,
+                patch: None,
+                tiny: None,
+                prerelease: prerelease.map(ToString::to_string),
+            });
         };
-        let minor = if segments.len() > 1 {
-            Some(
-                segments[1]
+
+        let major = segments
+            .next()
+            .map(|segment| {
+                segment
                     .parse::<u32>()
-                    .map_err(|_| RequestError::InvalidPart("minor version", input.to_string()))?,
-            )
-        } else {
-            None
-        };
-        let patch = if segments.len() > 2 {
-            Some(
-                segments[2]
+                    .map_err(|_| RequestError::InvalidPart("major version", input.to_string()))
+            })
+            .transpose()?;
+        let minor = segments
+            .next()
+            .map(|segment| {
+                segment
                     .parse::<u32>()
-                    .map_err(|_| RequestError::InvalidPart("patch version", input.to_string()))?,
-            )
-        } else {
-            None
-        };
-        let tiny = if segments.len() > 3 {
-            Some(
-                segments[3]
+                    .map_err(|_| RequestError::InvalidPart("minor version", input.to_string()))
+            })
+            .transpose()?;
+        let patch = segments
+            .next()
+            .map(|segment| {
+                segment
                     .parse::<u32>()
-                    .map_err(|_| RequestError::InvalidPart("tiny version", input.to_string()))?,
-            )
-        } else {
-            None
-        };
+                    .map_err(|_| RequestError::InvalidPart("patch version", input.to_string()))
+            })
+            .transpose()?;
+        let tiny = segments
+            .next()
+            .map(|segment| {
+                segment
+                    .parse::<u32>()
+                    .map_err(|_| RequestError::InvalidPart("tiny version", input.to_string()))
+            })
+            .transpose()?;
+
+        if segments.next().is_some() {
+            return Err(RequestError::TooManySegments(input.to_string()));
+        }
 
         Ok(RubyRequest {
             engine: engine.into(),
@@ -195,7 +194,7 @@ impl FromStr for RubyRequest {
             minor,
             patch,
             tiny,
-            prerelease,
+            prerelease: prerelease.map(ToString::to_string),
         })
     }
 }


### PR DESCRIPTION
Sped up some of the RubyRequest methods which I benchmarked earlier in https://github.com/spinel-coop/rv/pull/92 (this PR should be based on that one). On my Macbook Pro:

- Parsing (via FromStr trait) is 67% faster (by avoiding needless string copies for each segment)
- Calling `.number()` is 39% faster (it was allocating a string for all 4 of segments, but now it just appends to the single big output string)

Given that these functions already were measured in nanoseconds, this was completely unnecessary, but also, given that I'm on vacation and wanted to try optimizing something, the only time I'm wasting is my own.

<img width="685" height="257" alt="rubyrequest speedups" src="https://github.com/user-attachments/assets/0a14a555-b945-4656-ac2c-3b6488e4e5c7" />
