### PR TITLE
nit: Derive Ord

### DIFF
--- a/crates/rv-ruby/src/request.rs
+++ b/crates/rv-ruby/src/request.rs
@@ -6,7 +6,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 type VersionPart = u32;
 
-#[derive(Debug, Clone, PartialEq, Eq, DeserializeFromStr, SerializeDisplay)]
+#[derive(Debug, Clone, PartialEq, Eq, DeserializeFromStr, SerializeDisplay, PartialOrd, Ord)]
 pub struct RubyRequest {
     pub engine: RubyEngine,
     pub major: Option<VersionPart>,
@@ -233,33 +233,6 @@ impl Display for RubyRequest {
         };
 
         Ok(())
-    }
-}
-
-impl PartialOrd for RubyRequest {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for RubyRequest {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (
-            &self.engine,
-            &self.major,
-            &self.minor,
-            &self.patch,
-            &self.tiny,
-            &self.prerelease,
-        )
-            .cmp(&(
-                &other.engine,
-                &other.major,
-                &other.minor,
-                &other.patch,
-                &other.tiny,
-                &other.prerelease,
-            ))
     }
 }
 


### PR DESCRIPTION
The current implementation of Ord is actually
identical to what `derive(Ord, PartialOrd)` would do.
So IMO we may as well just derive it, it's less
code we need to read and worry about.

Obviously if you were aware of this and wanted
it to be written out manually that's fine, just
close this PR :)