### PR TITLE
Fuzz the Gemfile spec YAML parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Build
-      run: cargo build --release --all-features
+      run: cargo build --release --all-features --bin rv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +255,8 @@ version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1212,6 +1220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1250,16 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -1964,6 +1992,14 @@ dependencies = [
  "fs-err",
  "indoc",
  "tracing",
+]
+
+[[package]]
+name = "rv-fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "rv-gem-specification-yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/rv-gem-types",
   "crates/rv-ruby",
   "crates/rv-version",
+  "fuzz",
 ]
 resolver = "2"
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rv-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+rv-gem-specification-yaml = { path = "../crates/rv-gem-specification-yaml"}
+
+
+[[bin]]
+name = "parse_gem_spec_yaml"
+path = "fuzz_targets/parse_gem_spec_yaml.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse_gem_spec_yaml.rs
+++ b/fuzz/fuzz_targets/parse_gem_spec_yaml.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rv_gem_specification_yaml::parse;
+
+fuzz_target!(|data: &str| {
+    let _parse_res = parse(data);
+});


### PR DESCRIPTION
Integrates Cargo-fuzz. See the guide: https://rust-fuzz.github.io/book/cargo-fuzz.html

On MacOS you can run the fuzzer via

```
cargo +nightly fuzz run parse_gem_spec_yaml --target aarch64-apple-darwin
```

Note you'll need to install both Rust nightly and [`cargo-fuzz`](https://crates.io/crates/cargo-fuzz) binary.