### PR TITLE
perf: Remove unnecessary tokio::io::copy

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -5,6 +5,7 @@ use current_platform::CURRENT_PLATFORM;
 use futures_util::StreamExt;
 use owo_colors::OwoColorize;
 use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
 
 use rv_ruby::request::RubyRequest;
 
@@ -60,7 +61,7 @@ pub async fn install(
         download_ruby_tarball(&url, &tarball_path).await?;
     }
 
-    extract_ruby_tarball(&tarball_path, &install_dir).await?;
+    extract_ruby_tarball(&tarball_path, &install_dir)?;
 
     println!(
         "Installed Ruby version {} to {}",
@@ -105,14 +106,14 @@ async fn download_ruby_tarball(url: &str, tarball_path: &Utf8PathBuf) -> Result<
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
-        tokio::io::copy(&mut chunk.as_ref(), &mut file).await?;
+        file.write_all(&chunk).await?;
     }
 
     println!("Downloaded {} to {}", url.cyan(), tarball_path.cyan());
     Ok(())
 }
 
-async fn extract_ruby_tarball(tarball_path: &Utf8Path, dir: &Utf8Path) -> Result<()> {
+fn extract_ruby_tarball(tarball_path: &Utf8Path, dir: &Utf8Path) -> Result<()> {
     std::fs::create_dir_all(dir)?;
     let tarball = std::fs::File::open(tarball_path)?;
     let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(tarball));


### PR DESCRIPTION
When downloading a Ruby tarball, each chunk of the tarball is written to a file. Currently on main, this uses tokio::io::copy. But that's unnecessary as there's already a `write_all` method on the chunk.

Benchmark shows that removing the `tokio::io::copy` and using the `.write_all` is somewhat faster. On my 2023 Macbook Pro (with M2 Pro CPU):

```sh
# Make sure that `rv` in your $PATH refers to latest main,
# if it doesn't, then check out main and run `cargo install --path ./crates/rv`
# Compile this branch:
cargo build --release --quiet

# Run the benchmark
hyperfine -w1 \
'rv ruby install 3.4.1 -n' \
'./target/release/rv ruby install 3.4.1 -n'

./target/release/rv ruby install 3.4.1 -n ran
1.21 ± 0.30 times faster than rv ruby install 3.4.1 -n
```

The suggestion came from ChatGPT, but all coding and testing was done by me. I would love if other people could benchmark this 

I also noticed that the `extract_tarball` function was async but doesn't actually await anything, so I made it sync. Generally because `rv` does one thing at a time, async doesn't really have any benefit because there's no other operation trying to run concurrently.