### PR TITLE
Create tarball file *after* downloading tarball

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -95,14 +95,13 @@ fn tarball_path(config: &Config, url: impl AsRef<str>) -> Utf8PathBuf {
 }
 
 async fn download_ruby_tarball(url: &str, tarball_path: &Utf8PathBuf) -> Result<()> {
-    let mut file = tokio::fs::File::create(tarball_path).await?;
-
     let response = reqwest::get(url).await?;
     if !response.status().is_success() {
         return Err(Error::DownloadFailed(url.to_string(), response.status()));
     }
 
     let mut stream = response.bytes_stream();
+    let mut file = tokio::fs::File::create(tarball_path).await?;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
         tokio::io::copy(&mut chunk.as_ref(), &mut file).await?;


### PR DESCRIPTION
Currently, the tarball file is created on disk,
then the tarball itself is downloaded, and written to that file.

Problem is, if the download fails, the empty
file is left on disk. That means downloads get
skipped in the future, and the invalid tarball
causes errors when you try to extract it.

Solution: simply defer creating the file until
after we've downloaded the tarball that will be
written into it.

Tested manually by running `cargo run --quiet --bin rv -- ruby install 44.44.44` and ensuring that no entries were added to `~/.cache/rv/ruby-v0/tarballs/`

Fixes https://github.com/spinel-coop/rv/issues/86. There are other open PRs to fix the issue, but this is a simpler alternative. I have no preference about which PR eventually gets merged.