### PR TITLE
Validate tarball before using it

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -54,7 +54,7 @@ pub async fn install(
         std::fs::create_dir_all(tarball_path.parent().unwrap())?;
     }
 
-    if tarball_path.exists() {
+    if valid_tarball_exists(&tarball_path) {
         println!(
             "Tarball {} already exists, skipping download.",
             tarball_path.cyan()
@@ -72,6 +72,20 @@ pub async fn install(
     );
 
     Ok(())
+}
+
+/// Does a usable tarball already exist at this path?
+fn valid_tarball_exists(path: &Utf8Path) -> bool {
+    let Ok(f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(metadata) = f.metadata() else {
+        return false;
+    };
+    if metadata.len() == 0 {
+        return false;
+    }
+    true
 }
 
 fn ruby_url(version: &str) -> Result<String> {


### PR DESCRIPTION
When users run `rv ruby install`, it'll try to reuse an existing tarball in rv's cache.

Currently this logic just checks to see if a file exists. If it exists, we don't download it again. I think it should also check the file actually contains bytes (i.e. filesize > 0), because empty files _should_ be downloaded again. Skipping the download means the user can't download a valid tarball (pointed out in #86).

I ran hyperfine and found no statistically significant performance impact. If you'd like to measure performance on your machine too, just do:

```sh
cargo build --release --quiet

hyperfine -w1 \
'rv ruby install 3.4.1' \
'./target/release/rv ruby install 3.4.1'
```