### PR TITLE
Fix typo of uvx in plans doc

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -137,7 +137,7 @@ While Bundler invented the idea of `bundle exec` to run commands in the context 
 
 ## shortcut binaries
 
-In `uv`, the `run` and `exec` subcommands are both so common that they have their own dedicated binaries: `uvr` and `uxv`. This mirrors the `npm` shortcut for `npm exec`, which is named `npx`. That implies we should provide shortcut binaries named `rvr` and `rvx`.
+In `uv`, the `run` and `exec` subcommands are both so common that they have their own dedicated binaries: `uvr` and `uvx`. This mirrors the `npm` shortcut for `npm exec`, which is named `npx`. That implies we should provide shortcut binaries named `rvr` and `rvx`.
 
 ## what are "tools"?
 


### PR DESCRIPTION
See https://docs.astral.sh/uv/guides/tools/

---

The features of `rv` sound brilliant, and I'm excited to see where this goes! I particularly like the tools concept - I've previously had some difficulty around creating & distributing internal CLI tools with dependencies.

---

As an aside: My condolences regarding the hostile takeover of Bundler/RubyGems. I dearly hope the community can somehow regain control - great idea to [trademark Bundler](https://andre.arko.net/2025/09/25/bundler-belongs-to-the-ruby-community/)