### PR TITLE
fix(env): Set GEM_PATH to gem repository roots

### DIFF
--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -173,12 +173,12 @@ pub fn env_for(ruby: Option<&Ruby>) -> Result<(Vec<&'static str>, Vec<(&'static 
         insert("RUBY_VERSION", ruby.version.number());
         if let Some(gem_home) = ruby.gem_home() {
             paths.insert(0, gem_home.join("bin").into());
-            gem_paths.insert(0, gem_home.join("bin"));
+            gem_paths.insert(0, gem_home.clone());
             insert("GEM_HOME", gem_home.into_string());
         }
         if let Some(gem_root) = ruby.gem_root() {
             paths.insert(0, gem_root.join("bin").into());
-            gem_paths.insert(0, gem_root.join("bin"));
+            gem_paths.insert(0, gem_root.clone());
             insert("GEM_ROOT", gem_root.into_string());
         }
         let gem_path = join_paths(gem_paths)?;

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_ruby.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_ruby.snap
@@ -7,6 +7,6 @@ export RUBY_ROOT=/opt/rubies/ruby-3.3.5
 export RUBY_ENGINE=ruby
 export RUBY_VERSION=3.3.5
 export GEM_HOME=/tmp/home/.gem/ruby/3.3.5
-export GEM_PATH=/tmp/home/.gem/ruby/3.3.5/bin
+export GEM_PATH=/tmp/home/.gem/ruby/3.3.5
 export PATH='/tmp/home/.gem/ruby/3.3.5/bin:/opt/rubies/ruby-3.3.5/bin:/tmp/bin'
 hash -r


### PR DESCRIPTION
I'm not sure this is a bug per se, but I noticed some `bin/` directories in `GEM_PATH` and thought it might be incorrect. 

`gem_paths` is filled with `gem_home/bin` and `gem_root/bin`, not the `gem_home` or `gem_root` directories themselves. Because `GEM_PATH` no longer includes the standard ruby gem root, `GEM_HOME` is the only real repository in `Gem.path`. Default gems may still load (they’re handled specially), but any gems that were only in the system gem root (if the intention is to layer them) will not be discovered.

This fixes the construction of `GEM_PATH` to use the gem repository root directories (`gem_home` and `gem_root`) instead of their `bin` subdirectories. The `bin` directories are still correctly added to `PATH`.

The snapshot tests for the `shell env` command have been updated.

```diff
--- before.txt	2025-09-26 01:22:11
+++ after.txt	2025-09-26 01:22:43
@@ -1,4 +1,4 @@
root@06cc6d0fdf89:/home/user# gem env

 RubyGems Environment:
   - RUBYGEMS VERSION: 3.7.2
   - RUBY VERSION: 3.4.5 (2025-07-16 patchlevel 51) [aarch64-linux]
@@ -15,8 +15,7 @@
      - aarch64-linux
   - GEM PATHS:
      - /root/.gem/ruby/3.4.5
-     - /root/.rubies/ruby-3.4.5/lib/ruby/gems/3.4.0/bin
-     - /root/.gem/ruby/3.4.5/bin
+     - /root/.rubies/ruby-3.4.5/lib/ruby/gems/3.4.0
   - GEM CONFIGURATION:
      - :update_sources => true
      - :verbose => true
```