### PR TITLE
Prefer ChecksumAlgorithm over strings in more places

### DIFF
--- a/crates/rv-gem-package/src/error.rs
+++ b/crates/rv-gem-package/src/error.rs
@@ -2,6 +2,8 @@ use miette::Diagnostic;
 use std::io;
 use thiserror::Error;
 
+use crate::ChecksumAlgorithm;
+
 pub type Result<T> = miette::Result<T, Error>;
 
 #[derive(Error, Debug, Diagnostic)]
@@ -138,13 +140,13 @@ impl Error {
 
     pub fn checksum_mismatch(
         file_path: impl Into<String>,
-        algorithm: impl Into<String>,
+        algorithm: ChecksumAlgorithm,
         expected: impl Into<String>,
         actual: impl Into<String>,
     ) -> Self {
         ChecksumErrorKind::Mismatch {
             file_path: file_path.into(),
-            algorithm: algorithm.into(),
+            algorithm: algorithm.to_string(),
             expected: expected.into(),
             actual: actual.into(),
         }

--- a/crates/rv-gem-package/tests/integration_tests.rs
+++ b/crates/rv-gem-package/tests/integration_tests.rs
@@ -127,14 +127,30 @@ fn test_checksums_loading() {
 
     // Check available algorithms
     let algorithms: Vec<_> = checksums.algorithms().collect();
-    assert!(algorithms.contains(&"SHA256"));
-    assert!(algorithms.contains(&"SHA512"));
+    assert!(algorithms.contains(&ChecksumAlgorithm::Sha256));
+    assert!(algorithms.contains(&ChecksumAlgorithm::Sha512));
 
     // Check specific checksums exist
-    assert!(checksums.get_checksum("SHA256", "metadata.gz").is_some());
-    assert!(checksums.get_checksum("SHA256", "data.tar.gz").is_some());
-    assert!(checksums.get_checksum("SHA512", "metadata.gz").is_some());
-    assert!(checksums.get_checksum("SHA512", "data.tar.gz").is_some());
+    assert!(
+        checksums
+            .get_checksum(ChecksumAlgorithm::Sha256, "metadata.gz")
+            .is_some()
+    );
+    assert!(
+        checksums
+            .get_checksum(ChecksumAlgorithm::Sha256, "data.tar.gz")
+            .is_some()
+    );
+    assert!(
+        checksums
+            .get_checksum(ChecksumAlgorithm::Sha512, "metadata.gz")
+            .is_some()
+    );
+    assert!(
+        checksums
+            .get_checksum(ChecksumAlgorithm::Sha512, "data.tar.gz")
+            .is_some()
+    );
 }
 
 /// Test checksum verification success


### PR DESCRIPTION
The internals of rv-gem-package use ChecksumAlgorithm, an enum, in many places. But also, in a lot of places, it works with the stringified representation of those algorithms instead.

Working with the enums would be more type-safe (because you don't have to parse the enums out of the strings later) and also more efficient (because the enums don't require any stack allocations).

Also slightly bumped test coverage from 76% to 77%.