### PR TITLE
Rename old 'test' CI target to 'lint and format'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test
+  lint-and-fmt:
+    name: Lint and format
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
As of https://github.com/spinel-coop/rv/pull/112,
the new 'test with coverage' actions runs tests,
and the test target name is inaccurate.

@indirect this PR won't be mergeable until the CI is tweaked to require the new "Lint and format" job to be mandatory, and we should also make the "Test with coverage" job mandatory too.