### PR TITLE
Add integration tests for nushell support

### DIFF
--- a/crates/rv/tests/integration_tests/shell/env_test.rs
+++ b/crates/rv/tests/integration_tests/shell/env_test.rs
@@ -11,6 +11,15 @@ fn test_shell_env_succeeds() {
 }
 
 #[test]
+fn test_nushell_env_succeeds() {
+    let test = RvTest::new();
+    let output = test.rv(&["shell", "env", "nu"]);
+
+    assert_snapshot!(output.normalized_stdout());
+    assert!(output.success());
+}
+
+#[test]
 fn test_shell_env_with_path() {
     let mut test = RvTest::new();
     test.env.insert("PATH".into(), "/tmp/bin".into());

--- a/crates/rv/tests/integration_tests/shell/init_test.rs
+++ b/crates/rv/tests/integration_tests/shell/init_test.rs
@@ -11,6 +11,15 @@ fn test_shell_init_succeeds() {
 }
 
 #[test]
+fn test_nu_shell_init_succeeds() {
+    let test = RvTest::new();
+    let output = test.rv(&["shell", "init", "nu"]);
+    output.assert_success();
+
+    assert_snapshot!(output.normalized_stdout());
+}
+
+#[test]
 fn test_shell_init_fails_without_shell() {
     let test = RvTest::new();
     let output = test.rv(&["shell", "init"]);

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__nushell_env_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__nushell_env_succeeds.snap
@@ -1,0 +1,5 @@
+---
+source: crates/rv/tests/integration_tests/shell/env_test.rs
+expression: output.normalized_stdout()
+---
+{"GEM_HOME":{},"GEM_PATH":{},"GEM_ROOT":{},"PATH":"","RUBYOPT":{},"RUBY_ENGINE":{},"RUBY_ROOT":{},"RUBY_VERSION":{}}

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__init_test__nu_shell_init_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__init_test__nu_shell_init_succeeds.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rv/tests/integration_tests/shell/init_test.rs
+expression: output.normalized_stdout()
+---
+$env.config = ($env.config | upsert hooks.env_change.PWD {
+    [
+        {
+            |_, _| /tmp/bin/rv shell env nu | from json | load-env
+        }
+    ]
+})


### PR DESCRIPTION
These just snapshot the current output. In the future we should actually install nushell and test the command succeed.