### PR TITLE
dev: Set rv as the default executable in this workspace

### DIFF
--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 repository = "https://github.com/spinel-coop/rv"
 description = "Ruby version management, but fast"
 homepage = "https://spinel.coop/rv"
+default-run = "rv"
 
 [dependencies]
 clap = { workspace = true, features = ["derive", "env"] }


### PR DESCRIPTION
Before this change, if you run `cargo run` it'll
ask you to choose between rv and the gemfile parser.
That's because any ambiguous operation like "run
this crate" must be disambiguated by the user.

As of this change, it'll default to rv.