### PR TITLE
perf: Use 1 roundtrip to GitHub instead of 2 in ruby install

### DIFF
--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -80,16 +80,6 @@ impl RvTest {
             .with_body(content)
     }
 
-    /// Mock a github release for rv-ruby
-    pub fn mock_rv_ruby_release(&mut self, content: &[u8]) -> Mock {
-        let path = "/repos/spinel-coop/rv-ruby/releases/latest";
-        self.server
-            .mock("GET", path)
-            .with_status(200)
-            .with_header("content-type", "application/gzip")
-            .with_body(content)
-    }
-
     /// Get the server URL for constructing download URLs
     pub fn server_url(&self) -> String {
         self.server.url()

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -1,5 +1,4 @@
 use current_platform::CURRENT_PLATFORM;
-use rv_ruby::{Asset, Release};
 
 use crate::common::RvTest;
 use std::fs;
@@ -19,20 +18,8 @@ fn test_ruby_install_successful_download() {
 
     let tarball_content = create_mock_tarball();
     let download_suffix = make_dl_suffix("3.4.5");
-    let browser_download_url =
-        format!("https://github.com/spinel-coop/rv-ruby/releases/{download_suffix}");
     let _mock = test
         .mock_tarball_download(&download_suffix, &tarball_content)
-        .create();
-    let release = Release {
-        name: "2025MMDD".to_owned(),
-        assets: vec![Asset {
-            name: "3.4.5".to_owned(),
-            browser_download_url,
-        }],
-    };
-    let _mock_release = test
-        .mock_rv_ruby_release(serde_json::to_string(&release).unwrap().as_bytes())
         .create();
 
     test.env.remove("RV_NO_CACHE");
@@ -120,12 +107,10 @@ fn test_ruby_install_interrupted_download_cleanup() {
     let mut test = RvTest::new();
 
     let download_suffix = make_dl_suffix("3.4.5");
-    let browser_download_url =
-        format!("https://github.com/spinel-coop/rv-ruby/releases/{download_suffix}");
     #[cfg(target_os = "macos")]
     let _mock = test
         .server
-        .mock("GET", "/download/2025MMDD/ruby-3.4.5.arm64_sonoma.tar.gz")
+        .mock("GET", "/latest/download/ruby-3.4.5.arm64_sonoma.tar.gz")
         .with_status(200)
         .with_header("content-type", "application/gzip")
         .with_body("partial")
@@ -133,20 +118,10 @@ fn test_ruby_install_interrupted_download_cleanup() {
     #[cfg(target_os = "linux")]
     let _mock = test
         .server
-        .mock("GET", "/download/2025MMDD/ruby-3.4.5.x86_64_linux.tar.gz")
+        .mock("GET", "/latest/download/ruby-3.4.5.x86_64_linux.tar.gz")
         .with_status(200)
         .with_header("content-type", "application/gzip")
         .with_body("partial")
-        .create();
-    let release = Release {
-        name: "2025MMDD".to_owned(),
-        assets: vec![Asset {
-            name: "3.4.5".to_owned(),
-            browser_download_url,
-        }],
-    };
-    let _mock_release = test
-        .mock_rv_ruby_release(serde_json::to_string(&release).unwrap().as_bytes())
         .create();
 
     test.env.remove("RV_NO_CACHE");
@@ -188,8 +163,6 @@ fn test_ruby_install_cached_file_reused() {
 
     let tarball_content = create_mock_tarball();
     let download_suffix = make_dl_suffix("3.4.5");
-    let browser_download_url =
-        format!("https://github.com/spinel-coop/rv-ruby/releases/{download_suffix}");
     #[cfg(target_os = "macos")]
     let mock = test
         .mock_tarball_download(&download_suffix, &tarball_content)
@@ -199,16 +172,6 @@ fn test_ruby_install_cached_file_reused() {
     let mock = test
         .mock_tarball_download(&download_suffix, &tarball_content)
         .expect(1)
-        .create();
-    let release = Release {
-        name: "2025MMDD".to_owned(),
-        assets: vec![Asset {
-            name: "3.4.5".to_owned(),
-            browser_download_url,
-        }],
-    };
-    let _mock_release = test
-        .mock_rv_ruby_release(serde_json::to_string(&release).unwrap().as_bytes())
         .create();
 
     test.env.remove("RV_NO_CACHE");
@@ -266,7 +229,7 @@ fn make_dl_suffix(version: &str) -> String {
     let suffix = "arm64_linux";
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     let suffix = "x86_64_linux";
-    format!("download/2025MMDD/ruby-{version}.{suffix}.tar.gz")
+    format!("latest/download/ruby-{version}.{suffix}.tar.gz")
 }
 
 #[test]
@@ -275,8 +238,6 @@ fn test_ruby_install_atomic_rename_behavior() {
 
     let tarball_content = create_mock_tarball();
     let download_suffix = make_dl_suffix("3.4.5");
-    let browser_download_url =
-        format!("https://github.com/spinel-coop/rv-ruby/releases/{download_suffix}");
     #[cfg(target_os = "macos")]
     let _mock = test
         .mock_tarball_download(&download_suffix, &tarball_content)
@@ -284,16 +245,6 @@ fn test_ruby_install_atomic_rename_behavior() {
     #[cfg(target_os = "linux")]
     let _mock = test
         .mock_tarball_download(&download_suffix, &tarball_content)
-        .create();
-    let release = Release {
-        name: "2025MMDD".to_owned(),
-        assets: vec![Asset {
-            name: "3.4.5".to_owned(),
-            browser_download_url,
-        }],
-    };
-    let _mock_release = test
-        .mock_rv_ruby_release(serde_json::to_string(&release).unwrap().as_bytes())
         .create();
 
     test.env.remove("RV_NO_CACHE");


### PR DESCRIPTION
Previously in #132 aka f207164559e2a42aa63cb4c04f13bb435486830e, I used 2 roundtrips to download a ruby for `rv ruby install`. One roundtrip to get the latest rv-ruby release, and one roundtrip to download the right asset from it.

Andre pointed out that this can be done in one roundtrip, but I got tripped up because you have to swap the order of download and latest in that URL.

```sh
# this is HTTP 200
curl -L https://github.com/spinel-coop/rv-ruby/releases/download/20251006/ruby-3.3.0.arm64_linux.tar.gz

# This is a 404
curl -L https://github.com/spinel-coop/rv-ruby/releases/download/latest/ruby-3.3.0.arm64_linux.tar.gz

# swapping download/latest to latest/download gives a 200 though
curl -L https://github.com/spinel-coop/rv-ruby/releases/latest/download/ruby-3.3.0.arm64_linux.tar.gz
```

So, this should be faster, especially for users with slow internet. This PR runs `cargo nextest run --release -E "test(test_ruby_install_successful_download)"` in 486.0ms, and the previous latest main (with 2 roundtrips) in 591.9ms. The impact should be much larger for users on real internet connection, especially if their internet downloads are slow.
