### PR TITLE
Add more tests for rv ruby list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "mockito",
  "once_cell",
  "owo-colors",
+ "pretty_assertions",
  "rayon",
  "rayon-tracing",
  "regex",

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -61,3 +61,4 @@ indoc = { workspace = true }
 fs-err = { workspace = true }
 camino-tempfile-ext = { workspace = true }
 mockito = "1.4.0"
+pretty_assertions = { workspace = true }


### PR DESCRIPTION
Break out the pure/stateless/no-IO functionality from `rv ruby list` into its own function. Then unit test it.