### PR TITLE
Fix name of `backslack_escape` function

### DIFF
--- a/crates/rv/src/commands/shell/env.rs
+++ b/crates/rv/src/commands/shell/env.rs
@@ -35,7 +35,7 @@ pub fn env(config: &config::Config, shell: Shell) -> Result<()> {
                 println!("set -ge {}", unset.join(" "))
             }
             for (var, val) in set {
-                println!("set -gx {var} \"{}\"", backslack_escape(val))
+                println!("set -gx {var} \"{}\"", fish_var_escape(val))
             }
             Ok(())
         }
@@ -68,7 +68,7 @@ fn nu_env(unset: Vec<&str>, set: Vec<(&str, String)>) -> serde_json::Value {
 
 // From uv's crates/uv-shell/src/lib.rs
 // Assumes strings will be outputed as "str", so escapes any \ or " character
-fn backslack_escape(s: String) -> String {
+fn fish_var_escape(s: String) -> String {
     let mut escaped = String::with_capacity(s.len());
     for c in s.chars() {
         match c {


### PR DESCRIPTION
Just a very minor fix; this function seems to have been named with a typo (`backslack_escape` instead of `backslash_escape`). However, given it escapes both backslashes and quotes, I think it would probably benefit from just having a more generic name rather than fixing the typo itself.