### PR TITLE
feat: add about `rv shell completions` command help document

### DIFF
--- a/crates/rv/src/commands/shell.rs
+++ b/crates/rv/src/commands/shell.rs
@@ -18,7 +18,7 @@ pub enum ShellCommand {
         /// The shell to initialize (zsh, bash and fish so far)
         shell: Shell,
     },
-    #[command()]
+    #[command(about = "Configure shell completions to use rv")]
     Completions {
         /// The shell to print completions for (zsh, bash and fish so far)
         shell: Shell,


### PR DESCRIPTION
add  command help tips for `rv shell completions`  command.