### PR TITLE
bugfix: rv cache clean prints literal ASCII escapes

### DIFF
--- a/crates/rv/src/commands/cache.rs
+++ b/crates/rv/src/commands/cache.rs
@@ -5,7 +5,6 @@ use bytesize::ByteSize;
 use clap::{Args, Subcommand};
 use owo_colors::OwoColorize;
 use rv_cache::CleanReporter;
-use tracing::info;
 
 use crate::config::Config;
 
@@ -34,10 +33,11 @@ pub fn cache_clean(config: &Config) -> io::Result<()> {
         fn on_complete(&self) {}
     }
     let removal = config.cache.clear(Box::new(Reporter {}))?;
-    info!(
+    let num_bytes_cleaned = ByteSize::b(removal.bytes).display().iec_short();
+    println!(
         "Removed {} directories, totalling {}",
-        removal.dirs.default_color().cyan(),
-        ByteSize::b(removal.bytes).display().iec_short().cyan()
+        removal.dirs.cyan(),
+        num_bytes_cleaned.cyan()
     );
     Ok(())
 }


### PR DESCRIPTION
Root cause: using `tracing::info!` instead of `println!`. I guess the former doesn't support color.

tracing should be used for internal logs during development or debugging, println should be used for user output.

Closes https://github.com/spinel-coop/rv/issues/148