### PR TITLE
Fix Fish shell auto-switching on new tab/shell startup

### DIFF
--- a/crates/rv/src/commands/shell/init.rs
+++ b/crates/rv/src/commands/shell/init.rs
@@ -51,7 +51,8 @@ pub fn init(config: &Config, shell: Shell) -> Result<()> {
                     "function _rv_autoload_hook --on-variable PWD --description 'Change Ruby version on directory change using rv'\n",
                     "    status --is-command-substitution; and return\n",
                     "    {} shell env fish | source\n",
-                    "end\n"
+                    "end\n",
+                    "_rv_autoload_hook\n"
                 ),
                 config.current_exe
             );


### PR DESCRIPTION
## Problem
When opening a new Fish shell tab in the same directory (e.g., in WezTerm or other terminal emulators), the Ruby version was not automatically set based on `.ruby-version`. Users had to `cd` out and back into the directory to trigger the version switch.

## Root Cause
The Fish shell init script only defined a `--on-variable PWD` hook, which triggers when the working directory *changes*. However, when a new shell starts in a directory, `$PWD` is set but never "changes", so the hook never fires.

## Solution
Call `_rv_autoload_hook` immediately after defining it, matching the behavior already implemented for Zsh and Bash shells. This ensures the Ruby version is activated on shell startup, not just on directory changes.

## Changes
- Modified `crates/rv/src/commands/shell/init.rs` to call `_rv_autoload_hook` after function definition in Fish shell
- All existing tests pass

## Testing
Before:
```fish
$ rv shell init fish
function _rv_autoload_hook --on-variable PWD --description 'Change Ruby version on directory change using rv'
    status --is-command-substitution; and return
    /opt/homebrew/bin/rv shell env fish | source
end
```

After:
```fish
$ rv shell init fish
function _rv_autoload_hook --on-variable PWD --description 'Change Ruby version on directory change using rv'
    status --is-command-substitution; and return
    /opt/homebrew/bin/rv shell env fish | source
end
_rv_autoload_hook
```

Verified that opening new tabs in the same directory now correctly activates the Ruby version specified in `.ruby-version`.