### PR TITLE
turn on socks proxy support in reqwest

### DIFF
--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -35,7 +35,7 @@ tracing-indicatif = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anstream = { workspace = true }
 clap-verbosity-flag = { workspace = true, features = ["tracing"] }
-reqwest = { workspace = true, features = ["stream"] }
+reqwest = { workspace = true, features = ["stream", "socks"] }
 flate2 = { workspace = true }
 tar = { workspace = true }
 rv-cache = { workspace = true, features = ["clap"] }


### PR DESCRIPTION
This should be all we need to support SOCKS proxies, since this feature is supposed to make reqwest respect the usual SOCKS env vars.