### PR TITLE
Cross off completed ruby install tasks

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -23,14 +23,14 @@ All-in-one tooling for Ruby developers.
 - [x] `rv ruby pin`
 - [x] `rv ruby dir`
 - [ ] `rv ruby install`
-  - [ ] `rv ruby install 3.2.x`
-  - [ ] `rv ruby install 3.3.x`
   - [x] `rv ruby install 3.4.x`
+  - [x] `rv ruby install 3.3.x`
+  - [x] `rv ruby install 3.2.x`
   - [ ] `rv ruby install jruby 10`
   - [ ] `rv ruby install truffleruby 24`
   - [ ] `rv ruby install truffleruby+graalvm 24`
   - [ ] `rv ruby install mruby 3.3`
-- [ ] `rv ruby uninstall`
+- [x] `rv ruby uninstall`
 
 ### Gem CLI tools
 


### PR DESCRIPTION
We've got support for 3.3.x and 3.2.x now, so cross those off. I resorted the list since IMO it makes more sense that the latest Ruby version is on top.

`rv ruby uninstall` seems to work on `main`, so I crossed that off too.