### PR TITLE
Only cache `ci` gem downloads if they pass checksums

### DIFF
--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -776,22 +776,4 @@ mod tests {
         .await?;
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_ci_inner_requires_internet() -> Result<()> {
-        let file: Utf8PathBuf = "../rv-lockfile/tests/inputs/Gemfile.lock.empty".into();
-        let dir = file.parent().unwrap();
-        let cache = rv_cache::Cache::from_path("cache".to_owned());
-        ci_inner(
-            &cache,
-            &CiInnerArgs {
-                max_concurrent_requests: 10,
-                validate_checksums: true,
-                install_path: dir.into(),
-                lockfile_path: file,
-            },
-        )
-        .await?;
-        Ok(())
-    }
 }


### PR DESCRIPTION
If the download is corrupted, we don't want to cache it. So only cache if checksums are correct.

Also, check for HTTP request errors and return early if there was one.