### PR TITLE
rv ci: Use rv ruby, not system ruby

### DIFF
--- a/crates/rv/src/commands/ruby/run.rs
+++ b/crates/rv/src/commands/ruby/run.rs
@@ -17,6 +17,15 @@ pub enum Error {
 type Result<T> = miette::Result<T, Error>;
 
 pub fn run(config: &Config, request: &RubyRequest, args: &[String]) -> Result<()> {
+    let cmd = build_cmd(config, request, args)?;
+    exec(cmd)
+}
+
+pub(crate) fn build_cmd(
+    config: &Config,
+    request: &RubyRequest,
+    args: &[String],
+) -> Result<Command> {
     let Some(ruby) = config.matching_ruby(request) else {
         return Err(Error::NoMatchingRuby);
     };
@@ -29,8 +38,7 @@ pub fn run(config: &Config, request: &RubyRequest, args: &[String]) -> Result<()
     for (var, val) in set {
         cmd.env(var, val);
     }
-
-    exec(cmd)
+    Ok(cmd)
 }
 
 #[cfg(unix)]

--- a/crates/rv/tests/integration_tests/ci.rs
+++ b/crates/rv/tests/integration_tests/ci.rs
@@ -16,7 +16,7 @@ fn test_clean_install_download_test_gem() {
         .mock_gem_download("test-gem-1.0.0.gem", &tarball_content)
         .create();
 
-    let output = test.rv(&["ci", "--verbose"]);
+    let output = test.rv(&["ci", "--verbose", "--ruby", "3.4.7"]);
     output.assert_success();
     mock.assert();
 }


### PR DESCRIPTION
System ruby probably shouldn't be trusted,
this is rv after all, we should use rv ruby.