### PR TITLE
Install ruby version in `rv ruby run`

### DIFF
--- a/crates/rv/src/commands/ruby.rs
+++ b/crates/rv/src/commands/ruby.rs
@@ -69,6 +69,12 @@ pub enum RubyCommand {
     #[cfg(unix)]
     #[command(about = "Run a specific Ruby", dont_delimit_trailing_values = true)]
     Run {
+        /// By default, if your requested Ruby version isn't installed,
+        /// it will be installed with `rv ruby install`'s default options.
+        /// This option disables that behaviour.
+        #[arg(long)]
+        no_install: bool,
+
         /// Ruby version to run
         version: RubyRequest,
 

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -293,7 +293,11 @@ async fn run() -> Result<()> {
                     version: version_request,
                 } => ruby_uninstall(&config, version_request).await?,
                 #[cfg(unix)]
-                RubyCommand::Run { version, args } => ruby_run(&config, &version, &args)?,
+                RubyCommand::Run {
+                    version,
+                    no_install,
+                    args,
+                } => ruby_run(&config, &version, no_install, &args).await?,
             },
             Commands::Ci(ci_args) => ci(&config, ci_args).await?,
             Commands::Cache(cache) => match cache.command {

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -172,6 +172,7 @@ echo ""
     }
 }
 
+#[derive(Debug)]
 pub struct RvOutput {
     pub output: std::process::Output,
     pub test_root: String,

--- a/crates/rv/tests/integration_tests/ruby/mod.rs
+++ b/crates/rv/tests/integration_tests/ruby/mod.rs
@@ -1,4 +1,5 @@
 mod find_test;
 mod install_test;
 mod list_test;
+mod run_test;
 mod uninstall_test;

--- a/crates/rv/tests/integration_tests/ruby/run_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/run_test.rs
@@ -1,0 +1,65 @@
+use std::str::FromStr;
+
+use crate::common::{RvOutput, RvTest};
+use rv_ruby::request::RubyRequest;
+
+#[derive(Debug, Default)]
+pub struct RunOptions {
+    pub set_no_install: bool,
+}
+
+impl RvTest {
+    pub fn ruby_run(&self, version: RubyRequest, options: RunOptions, args: &[&str]) -> RvOutput {
+        let RunOptions { set_no_install } = options;
+        let mut cmd = self.rv_command();
+        cmd.args(["ruby", "run"]);
+        if set_no_install {
+            cmd.arg("--no-install");
+        }
+        cmd.args([&version.to_string(), "--"]);
+        cmd.args(args);
+
+        let output = cmd.output().expect("Failed to execute rv run");
+        RvOutput::new(self.temp_dir.path().as_str(), output)
+    }
+}
+
+#[test]
+fn test_ruby_run_simple() {
+    let test = RvTest::new();
+    test.create_ruby_dir("ruby-3.3.5");
+    let output = test.ruby_run(
+        RubyRequest::from_str("3.3.5").expect("this is a valid Ruby version"),
+        Default::default(),
+        &["-e", "'puts \"Hello, World\"'"],
+    );
+
+    assert!(output.success(), "rv ruby run should succeed");
+    assert!(output.stderr().is_empty());
+    assert_eq!(
+        output.normalized_stdout(),
+        "ruby\n3.3.5\naarch64-darwin23\naarch64\ndarwin23\n\n"
+    );
+}
+
+#[test]
+fn test_ruby_run_simple_no_install() {
+    let test = RvTest::new();
+    test.create_ruby_dir("ruby-3.3.5");
+
+    // This should pass because we already installed 3.3.5
+    let output = test.ruby_run(
+        RubyRequest::from_str("3.3.5").expect("this is a valid Ruby version"),
+        RunOptions {
+            set_no_install: true,
+        },
+        &["-e", "'puts \"Hello, World\"'"],
+    );
+
+    assert!(output.success(), "rv ruby run should succeed");
+    assert!(output.stderr().is_empty());
+    assert_eq!(
+        output.normalized_stdout(),
+        "ruby\n3.3.5\naarch64-darwin23\naarch64\ndarwin23\n\n"
+    );
+}


### PR DESCRIPTION
# User-facing docs

If you do `rv ruby run 3.4.2` and that version isn't installed, now `rv install 3.4.2` will be run. If you run in a secure environment where you don't want to install rubies from the default source, you can disable this behaviour via the `--no-install` flag.

Fixes https://github.com/spinel-coop/rv/issues/72

# Implementation

This just calls into the same code path as `rv ruby install`. It does so in-process, i.e. no shelling out or anything.