### PR TITLE
Simplify `valid_tarball_exists`

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -112,7 +112,7 @@ async fn extract_local_ruby_tarball(
 
 /// Does a usable tarball already exist at this path?
 fn valid_tarball_exists(path: &Utf8Path) -> bool {
-    std::fs::metadata(path).is_ok_and(|m| m.len() > 0)
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.len() > 0)
 }
 
 fn ruby_url(version: &str) -> Result<String> {


### PR DESCRIPTION
If we directly query for the metadata, we can inline the `File::open` call.

Then we can rely on the Result return to check that it succeeded and apply our extra condition check with `is_ok_and`.

@adamchalmers I'm trying to learn more Rust to contribute better to rv, do you think this is the same behavior? I'm not sure how to verify it better.