### PR TITLE
Update rust and cargo via dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,24 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+  - package-ecosystem: "cargo"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+  - package-ecosystem: "rust-toolchain"
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Added a 7 day cooldown for Cargo deps to make supply chain attacks less likely.