### PR TITLE
Replace uses of std::fs with fs_err

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -82,7 +82,7 @@ async fn download_and_extract_remote_tarball(
 
     let new_dir = tarball_path.parent().unwrap();
     if !new_dir.exists() {
-        std::fs::create_dir_all(new_dir)?;
+        fs_err::create_dir_all(new_dir)?;
     }
 
     if valid_tarball_exists(&tarball_path) {
@@ -112,7 +112,7 @@ async fn extract_local_ruby_tarball(
 
 /// Does a usable tarball already exist at this path?
 fn valid_tarball_exists(path: &Utf8Path) -> bool {
-    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.len() > 0)
+    fs_err::metadata(path).is_ok_and(|m| m.is_file() && m.len() > 0)
 }
 
 fn ruby_url(version: &str) -> Result<String> {
@@ -206,9 +206,9 @@ fn extract_ruby_tarball(
     version: &str,
 ) -> Result<()> {
     if !rubies_dir.exists() {
-        std::fs::create_dir_all(rubies_dir)?;
+        fs_err::create_dir_all(rubies_dir)?;
     }
-    let tarball = std::fs::File::open(tarball_path)?;
+    let tarball = fs_err::File::open(tarball_path)?;
     let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(tarball));
     for e in archive.entries()? {
         let mut entry = e?;

--- a/crates/rv/src/commands/ruby/list.rs
+++ b/crates/rv/src/commands/ruby/list.rs
@@ -454,9 +454,9 @@ mod tests {
     fn test_config() -> Result<Config> {
         let root = Utf8PathBuf::from(TempDir::new().unwrap().path().to_str().unwrap());
         let ruby_dir = root.join("opt/rubies");
-        std::fs::create_dir_all(&ruby_dir)?;
+        fs_err::create_dir_all(&ruby_dir)?;
         let current_dir = root.join("project");
-        std::fs::create_dir_all(&current_dir)?;
+        fs_err::create_dir_all(&current_dir)?;
 
         let config = Config {
             ruby_dirs: indexset![ruby_dir],
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn test_deser_release() {
-        let jtxt = std::fs::read_to_string("../../testdata/api.json").unwrap();
+        let jtxt = fs_err::read_to_string("../../testdata/api.json").unwrap();
         let release: Release = serde_json::from_str(&jtxt).unwrap();
         let actual = ruby_from_asset(&release.assets[0]).unwrap();
         let expected = Ruby {

--- a/crates/rv/src/commands/ruby/pin.rs
+++ b/crates/rv/src/commands/ruby/pin.rs
@@ -28,7 +28,7 @@ pub fn pin(config: &Config, version: Option<String>) -> Result<()> {
 fn set_pinned_ruby(config: &Config, version: String) -> Result<()> {
     let project_dir: Cow<Utf8PathBuf> = match config.requested_ruby {
         Some((_, Source::DotToolVersions(ref path))) => {
-            let versions = std::fs::read_to_string(path)?;
+            let versions = fs_err::read_to_string(path)?;
             let mut new_versions = String::new();
             let mut wrote_ruby = false;
             for line in versions.lines() {
@@ -44,16 +44,16 @@ fn set_pinned_ruby(config: &Config, version: String) -> Result<()> {
                 new_versions.push('\n');
             }
 
-            std::fs::write(path, new_versions)?;
+            fs_err::write(path, new_versions)?;
             Cow::Borrowed(path)
         }
         Some((_, Source::DotRubyVersion(ref path))) => {
-            std::fs::write(path, format!("{version}\n"))?;
+            fs_err::write(path, format!("{version}\n"))?;
             Cow::Borrowed(path)
         }
         Some((_, Source::Other)) | None => {
             let path = config.current_dir.join(".ruby-version");
-            std::fs::write(&path, format!("{version}\n"))?;
+            fs_err::write(&path, format!("{version}\n"))?;
             Cow::Owned(path)
         }
     };
@@ -97,9 +97,9 @@ mod tests {
     fn test_config() -> Result<Config> {
         let root = Utf8PathBuf::from(TempDir::new().unwrap().path().to_str().unwrap());
         let ruby_dir = root.join("opt/rubies");
-        std::fs::create_dir_all(&ruby_dir)?;
+        fs_err::create_dir_all(&ruby_dir)?;
         let current_dir = root.join("project");
-        std::fs::create_dir_all(&current_dir)?;
+        fs_err::create_dir_all(&current_dir)?;
 
         let config = Config {
             ruby_dirs: indexset![ruby_dir],
@@ -151,7 +151,7 @@ mod tests {
         // Verify the file was created
         let ruby_version_path = config.current_dir.join(".ruby-version");
         assert!(ruby_version_path.exists());
-        let content = std::fs::read_to_string(ruby_version_path).unwrap();
+        let content = fs_err::read_to_string(ruby_version_path).unwrap();
         assert_eq!(content, format!("{version}\n"));
     }
 
@@ -169,7 +169,7 @@ mod tests {
 
         // Verify the file contains the second version
         let ruby_version_path = config.current_dir.join(".ruby-version");
-        let content = std::fs::read_to_string(ruby_version_path).unwrap();
+        let content = fs_err::read_to_string(ruby_version_path).unwrap();
         assert_eq!(content, format!("{second_version}\n"));
     }
 
@@ -182,13 +182,13 @@ mod tests {
             Source::DotToolVersions(version_file.clone()),
         ));
 
-        std::fs::write(&version_file, "ruby 3.0.0").unwrap();
+        fs_err::write(&version_file, "ruby 3.0.0").unwrap();
 
         // Pin version (should overwrite)
         pin(&config, Some("3.4.0".to_string())).unwrap();
 
         // Verify the file contains the second version
-        let content = std::fs::read_to_string(&version_file).unwrap();
+        let content = fs_err::read_to_string(&version_file).unwrap();
         assert_eq!(content, "ruby 3.4.0\n");
     }
 
@@ -200,7 +200,7 @@ mod tests {
         pin(&config, Some(version.clone())).unwrap();
 
         let ruby_version_path = config.current_dir.join(".ruby-version");
-        let content = std::fs::read_to_string(ruby_version_path).unwrap();
+        let content = fs_err::read_to_string(ruby_version_path).unwrap();
         assert_eq!(content, format!("{version}\n"));
     }
 
@@ -212,7 +212,7 @@ mod tests {
         pin(&config, Some(version.clone())).unwrap();
 
         let ruby_version_path = config.current_dir.join(".ruby-version");
-        let content = std::fs::read_to_string(ruby_version_path).unwrap();
+        let content = fs_err::read_to_string(ruby_version_path).unwrap();
         assert_eq!(content, format!("{version}\n"));
     }
 }


### PR DESCRIPTION
fs_err has better error messages, e.g. if a file
is not found, it says which file it was trying
to find.

This involves an extra syscall but that's fine
for our use-case.