### PR TITLE
Fix release job errors

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,3 +27,8 @@ x86_64-apple-darwin = "macos-14"
 aarch64-apple-darwin = "macos-14"
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
 x86_64-unknown-linux-gnu = "ubuntu-24.04"
+
+[dist.github-action-commits]
+"actions/checkout" = "v6"
+"actions/upload-artifact" = "v4"
+"actions/download-artifact" = "v6"


### PR DESCRIPTION
changes dist to use the newest github actions that dependabot updated us to use
