### PR TITLE
rename `ci` to `clean-install` with ci alias, hide

### DIFF
--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -33,7 +33,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 
 #[derive(Debug, clap_derive::Args)]
-pub struct CiArgs {
+pub struct CleanInstallArgs {
     /// Maximum number of downloads that can be in flight at once.
     #[arg(short, long, default_value = "10")]
     pub max_concurrent_requests: usize,
@@ -105,7 +105,7 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-pub async fn ci(config: &Config, args: CiArgs) -> Result<()> {
+pub async fn ci(config: &Config, args: CleanInstallArgs) -> Result<()> {
     let lockfile_path = find_lockfile_path(config)?;
     let install_path = find_install_path(config, &lockfile_path).await?;
     let inner_args = CiInnerArgs {

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -17,7 +17,7 @@ pub mod config;
 
 use crate::commands::cache::{CacheCommand, CacheCommandArgs, cache_clean, cache_dir, cache_prune};
 #[cfg(unix)]
-use crate::commands::ci::{CiArgs, ci};
+use crate::commands::ci::{CleanInstallArgs, ci};
 use crate::commands::ruby::dir::dir as ruby_dir;
 use crate::commands::ruby::find::find as ruby_find;
 use crate::commands::ruby::install::install as ruby_install;
@@ -130,9 +130,13 @@ enum Commands {
     Cache(CacheCommandArgs),
     #[command(about = "Configure your shell to use rv")]
     Shell(ShellArgs),
-    #[command(about = "Clean install from a Gemfile.lock")]
     #[cfg(unix)]
-    Ci(CiArgs),
+    #[command(
+        about = "Clean install from a Gemfile.lock",
+        visible_alias = "ci",
+        hide = true
+    )]
+    CleanInstall(CleanInstallArgs),
 }
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]
@@ -319,7 +323,7 @@ async fn run_cmd(config: &Config, command: Commands) -> Result<()> {
             .map(|_| ())?,
         },
         #[cfg(unix)]
-        Commands::Ci(ci_args) => ci(config, ci_args).await?,
+        Commands::CleanInstall(ci_args) => ci(config, ci_args).await?,
         Commands::Cache(cache) => match cache.command {
             CacheCommand::Dir => cache_dir(config)?,
             CacheCommand::Clean => cache_clean(config)?,


### PR DESCRIPTION
change the official command name to clean-install so people know what we mean, while keeping `ci` as an alias. also hide it for now so we can release even while it doesn't fully work.
