### PR TITLE
build rv locked in OS integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
-        run: apk add --no-cache musl-dev build-base
+        run: |
+          apk add --no-cache build-base
       - name: Build rv
-        run: cargo build --release
+        run: cargo build --release --locked --bin rv
       - name: Test rv works
         run: |
           ./target/release/rv --version
@@ -33,11 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
-        run: pacman -Syu --noconfirm base-devel rustup
-      - name: Install Rust toolchain
-        run: rustup default stable
+        run: pacman -Syu --noconfirm base-devel rust
       - name: Build rv
-        run: cargo build --release
+        run: cargo build --release --locked --bin rv
       - name: Test rv works
         run: |
           ./target/release/rv --version


### PR DESCRIPTION
As suggested by @orhun in [this comment](https://github.com/spinel-coop/rv/pull/193#discussion_r2581477840), build rv with `--locked`. While we're at it, install as few packages as possible, and only build the `rv` bin itself.
