### PR TITLE
Let `rv ruby pin` show consistent ruby version output format

### DIFF
--- a/crates/rv/src/commands/ruby/pin.rs
+++ b/crates/rv/src/commands/ruby/pin.rs
@@ -31,7 +31,7 @@ pub fn pin(config: &Config, version: Option<String>) -> Result<()> {
 }
 
 fn set_pinned_ruby(config: &Config, version: String) -> Result<()> {
-    RubyRequest::from_str(&version)?;
+    let requested_version = RubyRequest::from_str(&version)?;
 
     let project_dir: Cow<Utf8PathBuf> = match config.requested_ruby {
         Some((_, Source::DotToolVersions(ref path))) => {
@@ -65,7 +65,11 @@ fn set_pinned_ruby(config: &Config, version: String) -> Result<()> {
         }
     };
 
-    println!("{0} pinned to Ruby {1}", project_dir.cyan(), version.cyan());
+    println!(
+        "{0} pinned to {1}",
+        project_dir.cyan(),
+        requested_version.cyan()
+    );
 
     Ok(())
 }
@@ -86,11 +90,7 @@ fn show_pinned_ruby(config: &Config) -> Result<()> {
         }
     };
 
-    println!(
-        "{0} is pinned to Ruby {1}",
-        dir.as_ref().cyan(),
-        ruby.cyan()
-    );
+    println!("{0} is pinned to {1}", dir.as_ref().cyan(), ruby.cyan());
     Ok(())
 }
 

--- a/crates/rv/tests/integration_tests/ruby/mod.rs
+++ b/crates/rv/tests/integration_tests/ruby/mod.rs
@@ -1,5 +1,6 @@
 mod find_test;
 mod install_test;
 mod list_test;
+mod pin_test;
 mod run_test;
 mod uninstall_test;

--- a/crates/rv/tests/integration_tests/ruby/pin_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/pin_test.rs
@@ -1,0 +1,31 @@
+use crate::common::{RvOutput, RvTest};
+
+impl RvTest {
+    pub fn ruby_pin(&self, args: &[&str]) -> RvOutput {
+        let mut cmd = self.rv_command();
+        cmd.args(["ruby", "pin"]);
+        cmd.args(args);
+
+        let output = cmd.output().expect("Failed to execute rv command");
+        RvOutput::new(self.temp_dir.path().as_str(), output)
+    }
+}
+
+#[test]
+fn test_ruby_pin_ruby_output_format_consistency() {
+    let test = RvTest::new();
+
+    let set_pin = test.ruby_pin(&["3.4.7"]);
+    assert!(set_pin.success());
+    assert_eq!(
+        set_pin.normalized_stdout(),
+        "/.ruby-version pinned to ruby-3.4.7\n"
+    );
+
+    let show_pin = test.ruby_pin(&[]);
+    assert!(show_pin.success());
+    assert_eq!(
+        show_pin.normalized_stdout(),
+        "/.ruby-version is pinned to ruby-3.4.7\n"
+    );
+}


### PR DESCRIPTION
Previously, pinning would printing different output format depending on whether you passed a version as an argument or not:

```
$ rv ruby pin 3.4.7
/path/to/.ruby-version pinned to Ruby 3.4.7

$ rv ruby pin
/path/to/.ruby-version is pinned to Ruby ruby-3.4.7
```

The new output is more consistent, like this:

```
$ rv ruby pin 3.4.7
/path/to/.ruby-version pinned to ruby-3.4.7

$ rv ruby pin
/path/to/.ruby-version is pinned to ruby-3.4.7
```

It should also feel less redundant from non default implementations, like JRuby.