### PR TITLE
'find' command should use RubyRequest not String

### DIFF
--- a/crates/rv/src/commands/ruby.rs
+++ b/crates/rv/src/commands/ruby.rs
@@ -43,7 +43,7 @@ pub enum RubyCommand {
     #[command(about = "Search for a Ruby installation")]
     Find {
         /// Ruby version to find
-        version: Option<String>,
+        version: Option<RubyRequest>,
     },
 
     #[command(about = "Install a Ruby version")]

--- a/crates/rv/src/commands/ruby/find.rs
+++ b/crates/rv/src/commands/ruby/find.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use anstream::println;
 use owo_colors::OwoColorize;
 use rv_ruby::request::RubyRequest;
@@ -18,10 +16,10 @@ pub enum Error {
 
 type Result<T> = miette::Result<T, Error>;
 
-pub fn find(config: &Config, version: Option<String>) -> Result<()> {
+pub fn find(config: &Config, version: Option<RubyRequest>) -> Result<()> {
     let request = match version {
         None => config.ruby_request()?,
-        Some(version) => RubyRequest::from_str(&version)?,
+        Some(version) => version,
     };
     if let Some(ruby) = config.matching_ruby(&request) {
         println!("{}", ruby.executable_path().cyan());

--- a/crates/rv/tests/integration_tests/ruby/find_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/find_test.rs
@@ -41,7 +41,7 @@ fn test_ruby_find_invalid_version() {
     find.assert_failure();
     assert_eq!(
         find.normalized_stderr(),
-        "Error: FindError(InvalidVersion(TooManySegments(\"3.4.5.6.7\")))\n"
+        "error: invalid value '3.4.5.6.7' for '[VERSION]': Could not parse version 3.4.5.6.7, no more than 4 numbers are allowed\n\nFor more information, try '--help'.\n",
     );
 }
 


### PR DESCRIPTION
Similar to https://github.com/spinel-coop/rv/pull/241, now that clap gives better error messages because we've stopped gaslighting the compiler haha