### PR TITLE
Use lints in rv crate

### DIFF
--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -72,3 +72,7 @@ fs-err = { workspace = true }
 camino-tempfile-ext = { workspace = true }
 mockito = "1.4.0"
 pretty_assertions = { workspace = true }
+
+[lints]
+workspace = true
+

--- a/crates/rv/src/commands/shell/env.rs
+++ b/crates/rv/src/commands/shell/env.rs
@@ -9,6 +9,8 @@ pub enum Error {
     ConfigError(#[from] config::Error),
     #[error("No Ruby installations found in configuration.")]
     NoRubyFound,
+    #[error("Could not serialize JSON: {0}")]
+    Serde(#[from] serde_json::Error),
 }
 
 type Result<T> = miette::Result<T, Error>;
@@ -43,7 +45,7 @@ pub fn env(config: &config::Config, shell: Shell) -> Result<()> {
             // Emit JSON which will be run by `load-env`.
             // See <https://www.nushell.sh/commands/docs/load-env.html>
             let env_json = nu_env(unset, set);
-            let serialized = serde_json::to_string(&env_json).expect("serializing JSON");
+            let serialized = serde_json::to_string(&env_json)?;
             println!("{}", serialized);
             Ok(())
         }

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -128,7 +128,7 @@ pub fn find_requested_ruby(
     root: Utf8PathBuf,
 ) -> Result<Option<(RubyRequest, Source)>> {
     debug!("Searching for project directory in {}", current_dir);
-    let mut project_dir = current_dir.clone();
+    let mut project_dir = current_dir;
 
     loop {
         let ruby_version = project_dir.join(".ruby-version");

--- a/crates/rv/src/config/ruby_cache.rs
+++ b/crates/rv/src/config/ruby_cache.rs
@@ -285,6 +285,6 @@ mod tests {
 
         // Should return cache miss for uncached Ruby
         let result = config.get_cached_ruby(&ruby_path);
-        assert!(result.is_err());
+        result.unwrap_err();
     }
 }

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -269,6 +269,6 @@ impl RvOutput {
             output = output.replace('\\', "/");
         }
 
-        output.to_string()
+        output
     }
 }


### PR DESCRIPTION
I enabled some workspace-wide lints in https://github.com/spinel-coop/rv/pull/195, but didn't realize workspace members have to explicitly opt into using them. Let's enable them in the main rv crate.