### PR TITLE
Cleanup: remove explicit indexing

### DIFF
--- a/crates/rv-gem-types/src/dependency.rs
+++ b/crates/rv-gem-types/src/dependency.rs
@@ -80,12 +80,15 @@ impl Dependency {
 
     pub fn is_latest_version(&self) -> bool {
         // Check if the requirement is just ">= 0"
+        let Some(constraint) = self.requirement.constraints.first() else {
+            return false;
+        };
         self.requirement.constraints.len() == 1
             && matches!(
-                self.requirement.constraints[0].operator,
+                constraint.operator,
                 crate::requirement::ComparisonOperator::GreaterEqual
             )
-            && self.requirement.constraints[0].version.to_string() == "0"
+            && constraint.version.to_string() == "0"
     }
 
     pub fn is_specific(&self) -> bool {

--- a/crates/rv-gem-types/src/name_tuple.rs
+++ b/crates/rv-gem-types/src/name_tuple.rs
@@ -21,18 +21,14 @@ impl NameTuple {
     }
 
     pub fn from_array(array: &[String]) -> Result<Self, NameTupleError> {
-        if !(2..=3).contains(&array.len()) {
+        let Some(name) = array.first().cloned() else {
             return Err(NameTupleError::InvalidArray);
-        }
-
-        let name = array[0].clone();
-        let version = Version::new(&array[1])?;
-        let platform = if array.len() == 3 {
-            Some(array[2].clone())
-        } else {
-            None
         };
-
+        let Some(version) = array.get(1).map(Version::new) else {
+            return Err(NameTupleError::InvalidArray);
+        };
+        let version = version?;
+        let platform = array.get(2).cloned();
         Ok(Self::new(name, version, platform))
     }
 

--- a/crates/rv-gem-types/src/platform.rs
+++ b/crates/rv-gem-types/src/platform.rs
@@ -78,7 +78,12 @@ impl Platform {
     fn parse_platform_string(platform: &str) -> Result<Platform, PlatformError> {
         let platform = platform.trim_end_matches('-');
         let parts: Vec<&str> = platform.splitn(2, '-').collect();
-        let cpu = parts[0];
+        let Some(cpu) = parts.first() else {
+            return Err(PlatformError::InvalidPlatform {
+                platform: platform.to_owned(),
+            });
+        };
+        let cpu = *cpu;
         let mut os = parts.get(1).map(|os| Cow::from(*os));
 
         let cpu = if I386_REGEX.is_match(cpu) {

--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -341,10 +341,7 @@ impl ArchiveChecksums {
     fn new(file: &str) -> Option<Self> {
         use saphyr::{LoadableYamlNode, Yaml};
         let contents_yaml = Yaml::load_from_str(file).ok()?;
-        if contents_yaml.is_empty() {
-            return None;
-        }
-        let root = &contents_yaml[0];
+        let root = contents_yaml.first()?;
         let mut out = ArchiveChecksums::default();
 
         if let Some(checksums) = root.as_mapping_get("SHA256") {


### PR DESCRIPTION
`array[0]` can panic if the array's length is <1.
Usually we've got a runtime check protecting against this, but using `.get()` or `.first()` moves this check into compile-time rather than runtime :)