### PR TITLE
Reject running `rv` without a command

### DIFF
--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -70,7 +70,7 @@ struct Cli {
     cache_args: CacheArgs,
 
     #[command(subcommand)]
-    command: Option<Commands>,
+    command: Commands,
 
     /// Root directory for testing (hidden)
     #[arg(long, hide = true, env = "RV_ROOT_DIR")]
@@ -279,10 +279,7 @@ async fn run() -> Result<()> {
     }
 
     let config = cli.config()?;
-    let Some(cmd) = cli.command else {
-        return Ok(());
-    };
-    run_cmd(&config, cmd).await
+    run_cmd(&config, cli.command).await
 }
 
 /// Run an `rv` subcommand.

--- a/crates/rv/tests/integration_tests/main.rs
+++ b/crates/rv/tests/integration_tests/main.rs
@@ -2,3 +2,19 @@ mod ci;
 mod common;
 mod ruby;
 mod shell;
+
+use crate::common::RvTest;
+use regex::Regex;
+
+#[test]
+fn test_no_command() {
+    let test = RvTest::new();
+    let result = test.rv(&["--color=always"]);
+    result.assert_failure();
+    let stderr = result.stderr();
+    let error_re = Regex::new(r"(?s)\n  \[subcommands:.*");
+    assert_eq!(
+        error_re.unwrap().replace(&stderr, ""),
+        "error: 'rv' requires a subcommand but one was not provided",
+    );
+}


### PR DESCRIPTION
Right now, running `rv` with flags, but without a command, succeeds, and prints nothing (except for `rv --verbose` which also seems to do nothing but does print some debug info).

I think it's better to reject those usages with a helpful error.

Note that `--version` and `--help` are special and still work. And also running `rv` without flags nor commands still prints help as before.

#### Before

```
$ rv --color=always
$ echo $?
0
```

#### After

```
$ rv --color=always
error: 'rv' requires a subcommand but one was not provided
  [subcommands: ruby, cache, shell, clean-install, ci, help]

Usage: rv [OPTIONS] <COMMAND>

For more information, try '--help'.
$ echo $?
2
```