### PR TITLE
Add a `--fix` flag to `bin/lint` to fix issues

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -2,5 +2,11 @@
 set -euo pipefail
 set -x
 
-cargo fmt --all -- --check
+if [ $# -gt 0 ] && [ "$1" = "--fix" ]
+then
+  cargo fmt --all
+else
+  cargo fmt --all -- --check
+fi
+
 cargo clippy --all-targets --all-features "$@" -- -D warnings


### PR DESCRIPTION
A `--fix` flag is already passed around to `clippy`. I think we can reuse it to automatically fix `fmt` issues as well. 