### PR TITLE
Pass `--gemfile` flag only to commands that need it

### DIFF
--- a/crates/rv/src/commands/ruby/list.rs
+++ b/crates/rv/src/commands/ruby/list.rs
@@ -469,7 +469,6 @@ mod tests {
 
         let config = Config {
             ruby_dirs: indexset![ruby_dir],
-            gemfile: None,
             current_exe: root.join("bin").join("rv"),
             requested_ruby: Some(("3.5.0".parse().unwrap(), Source::Other)),
             current_dir,

--- a/crates/rv/src/commands/ruby/pin.rs
+++ b/crates/rv/src/commands/ruby/pin.rs
@@ -110,7 +110,6 @@ mod tests {
 
         let config = Config {
             ruby_dirs: indexset![ruby_dir],
-            gemfile: None,
             current_exe: root.join("bin").join("rv"),
             requested_ruby: Some(("3.5.0".parse().unwrap(), Source::Other)),
             current_dir,

--- a/crates/rv/src/commands/shell/env.rs
+++ b/crates/rv/src/commands/shell/env.rs
@@ -102,7 +102,6 @@ mod tests {
 
         let config = Config {
             ruby_dirs: indexset![ruby_dir],
-            gemfile: None,
             current_exe: root.join("bin").join("rv"),
             requested_ruby: Some(("3.5.0".parse().unwrap(), Source::Other)),
             current_dir,

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -33,7 +33,6 @@ type Result<T> = miette::Result<T, Error>;
 #[derive(Debug)]
 pub struct Config {
     pub ruby_dirs: IndexSet<Utf8PathBuf>,
-    pub gemfile: Option<Utf8PathBuf>,
     pub root: Utf8PathBuf,
     pub current_dir: Utf8PathBuf,
     pub cache: rv_cache::Cache,
@@ -271,7 +270,6 @@ mod tests {
 
         Config {
             ruby_dirs: indexset![ruby_dir],
-            gemfile: None,
             current_exe: root.join("bin").join("rv"),
             requested_ruby: Some(("3.5.0".parse().unwrap(), Source::Other)),
             current_dir,

--- a/crates/rv/src/config/ruby_cache.rs
+++ b/crates/rv/src/config/ruby_cache.rs
@@ -170,7 +170,6 @@ mod tests {
 
         let config = Config {
             ruby_dirs: indexset![ruby_dir],
-            gemfile: None,
             root: root.clone(),
             current_dir: root.clone(),
             cache: Cache::temp().unwrap(),

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -52,10 +52,6 @@ struct Cli {
     #[arg(long = "ruby-dir", env = "RUBIES_PATH", value_delimiter = ':')]
     ruby_dir: Vec<Utf8PathBuf>,
 
-    /// Path to Gemfile
-    #[arg(long, env = "BUNDLE_GEMFILE")]
-    gemfile: Option<Utf8PathBuf>,
-
     #[command(flatten)]
     verbose: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
 
@@ -112,7 +108,6 @@ impl Cli {
 
         Ok(Config {
             ruby_dirs,
-            gemfile: self.gemfile.clone(),
             root,
             current_dir,
             cache,

--- a/crates/rv/tests/integration_tests/main.rs
+++ b/crates/rv/tests/integration_tests/main.rs
@@ -18,3 +18,15 @@ fn test_no_command() {
         "error: 'rv' requires a subcommand but one was not provided",
     );
 }
+
+#[test]
+fn test_global_flags() {
+    let test = RvTest::new();
+    let result = test.rv(&["--help"]);
+    result.assert_success();
+    let stdout = result.stdout();
+    assert!(
+        !stdout.contains("--gemfile"),
+        "--gemfile should not be a global flag"
+    );
+}


### PR DESCRIPTION
Currently `--gemfile` is considered a global flag (i.e., a flag that applies to all commands):

```
$ rv --help
Ruby version management, but fast

Usage: rv [OPTIONS] [COMMAND]

Commands:
  ruby   Manage Ruby versions and installations
  cache  Manage rv's cache
  shell  Configure your shell to use rv
  help   Print this message or the help of the given subcommand(s)

Options:
      --ruby-dir <RUBY_DIR>  Ruby directories to search for installations [env: RUBIES_PATH=]
      --gemfile <GEMFILE>    Path to Gemfile [env: BUNDLE_GEMFILE=]
  -v, --verbose...           Increase logging verbosity
  -q, --quiet...             Decrease logging verbosity
  -h, --help                 
      --color <COLOR>        [env: RV_COLOR=] [possible values: auto, always, never]
  -V, --version              Print version

Cache Options:
  -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation [env: RV_NO_CACHE=]
      --cache-dir <CACHE_DIR>  Path to the cache directory [env: RV_CACHE_DIR=]

```

However, in reality, only the `rv ci` command uses it. In addition, the `rv ci` command does not document it at all:

```
$ rv ci --help
Clean install from a Gemfile.lock

Usage: rv clean-install [OPTIONS]

Options:
  -m, --max-concurrent-requests <MAX_CONCURRENT_REQUESTS>
          Maximum number of downloads that can be in flight at once [default: 10]
      --max-concurrent-installs <MAX_CONCURRENT_INSTALLS>
          Maximum number of gem installations that can be in flight at once. This reduces concurrently-open files on your filesystem, and concurrent disk operations [default: 20]
  -v, --verbose...
          Increase logging verbosity
      --validate-checksums
          Validate the checksums from the gem server and gem itself
  -q, --quiet...
          Decrease logging verbosity
  -h, --help
          

Cache Options:
  -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation [env: RV_NO_CACHE=]
      --cache-dir <CACHE_DIR>  Path to the cache directory [env: RV_CACHE_DIR=]
```

I think it's better to pass it only to the commands using it. So, it doesn't show up as a global flag, but as a flag specific to `rv ci`:

```
$ rv --help
Ruby version management, but fast

Usage: rv [OPTIONS] [COMMAND]

Commands:
  ruby   Manage Ruby versions and installations
  cache  Manage rv's cache
  shell  Configure your shell to use rv
  help   Print this message or the help of the given subcommand(s)

Options:
      --ruby-dir <RUBY_DIR>  Ruby directories to search for installations [env: RUBIES_PATH=]
  -v, --verbose...           Increase logging verbosity
  -q, --quiet...             Decrease logging verbosity
  -h, --help                 
      --color <COLOR>        [env: RV_COLOR=] [possible values: auto, always, never]
  -V, --version              Print version

Cache Options:
  -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation [env: RV_NO_CACHE=]
      --cache-dir <CACHE_DIR>  Path to the cache directory [env: RV_CACHE_DIR=]
```

```
$ rv ci --help
Clean install from a Gemfile.lock

Usage: rv clean-install [OPTIONS]

Options:
      --gemfile <GEMFILE>
          Path to Gemfile [env: BUNDLE_GEMFILE=]
  -m, --max-concurrent-requests <MAX_CONCURRENT_REQUESTS>
          Maximum number of downloads that can be in flight at once [default: 10]
  -v, --verbose...
          Increase logging verbosity
      --max-concurrent-installs <MAX_CONCURRENT_INSTALLS>
          Maximum number of gem installations that can be in flight at once. This reduces concurrently-open files on your filesystem, and concurrent disk operations [default: 20]
  -q, --quiet...
          Decrease logging verbosity
  -h, --help
          
      --validate-checksums
          Validate the checksums from the gem server and gem itself

Cache Options:
  -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation [env: RV_NO_CACHE=]
      --cache-dir <CACHE_DIR>  Path to the cache directory [env: RV_CACHE_DIR=]
 ```

That's what this PR implements.