### PR TITLE
Add `rv shell <zsh|bash|fish|nu>`

### DIFF
--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -61,13 +61,13 @@ saphyr.workspace = true
 sha2.workspace = true
 hex = "0.4.3"
 assert_fs.workspace = true
+indoc.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
 tracing-test = { workspace = true }
 tempfile = { workspace = true }
 assert_fs = { workspace = true }
-indoc = { workspace = true }
 fs-err = { workspace = true }
 camino-tempfile-ext = { workspace = true }
 mockito = "1.4.0"

--- a/crates/rv/src/commands/shell.rs
+++ b/crates/rv/src/commands/shell.rs
@@ -2,32 +2,29 @@ pub mod completions;
 pub mod env;
 pub mod init;
 
+use crate::config::Config;
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
 #[derive(Args)]
+#[command(args_conflicts_with_subcommands = true)]
+#[group(required = true, multiple = false)]
 pub struct ShellArgs {
+    #[arg(value_enum)]
+    pub shell: Option<Shell>,
+
     #[command(subcommand)]
-    pub command: ShellCommand,
+    pub command: Option<ShellCommand>,
 }
 
 #[derive(Subcommand)]
 pub enum ShellCommand {
-    #[command(about = "Configure your shell to use rv")]
-    Init {
-        /// The shell to initialize (zsh, bash and fish so far)
-        shell: Shell,
-    },
-    #[command(about = "Configure shell completions to use rv")]
-    Completions {
-        /// The shell to print completions for (zsh, bash and fish so far)
-        shell: Shell,
-    },
     #[command(hide = true)]
-    Env {
-        /// The shell to configure (zsh, bash and fish so far)
-        shell: Shell,
-    },
+    Init { shell: Shell },
+    #[command(hide = true)]
+    Completions { shell: Shell },
+    #[command(hide = true)]
+    Env { shell: Shell },
 }
 
 #[derive(clap::ValueEnum, Clone, Default, Debug, Serialize)]
@@ -37,4 +34,80 @@ pub enum Shell {
     Bash,
     Fish,
     Nu,
+}
+
+impl std::fmt::Display for Shell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Zsh => write!(f, "zsh"),
+            Self::Bash => write!(f, "bash"),
+            Self::Fish => write!(f, "fish"),
+            Self::Nu => write!(f, "nu"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+pub enum Error {
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+}
+
+type Result<T> = miette::Result<T, Error>;
+
+pub fn setup(config: &Config, shell: Shell) -> Result<()> {
+    use indoc::{formatdoc, printdoc};
+
+    let name = shell.to_string();
+
+    let header = formatdoc! {"
+        Install rv's shell integration into {name} by running the commands below,
+        or configuring your shell to do the equivalent."
+    };
+
+    let rv = &config.current_exe;
+
+    match shell {
+        Shell::Zsh => {
+            printdoc! {"
+                {header}
+
+                echo 'eval \"$({rv} shell init zsh)\"' >> ~/.zshrc
+                echo 'eval \"$({rv} shell completions zsh)\"' >> ~/.zshrc
+            "};
+
+            Ok(())
+        }
+        Shell::Bash => {
+            printdoc! {"
+                {header}
+
+                echo 'eval \"$({rv} shell init bash)\"' >> ~/.bashrc
+                echo 'eval \"$({rv} shell completions bash)\"' >> ~/.bashrc
+            "};
+
+            Ok(())
+        }
+        Shell::Fish => {
+            printdoc! {"
+                {header}
+
+                echo '{rv} shell init fish | source' >> ~/.config/fish/config.fish
+                echo '{rv} shell completions fish | source' >> ~/.config/fish/config.fish
+            "};
+
+            Ok(())
+        }
+        Shell::Nu => {
+            printdoc! {"
+                {header}
+
+                echo 'mkdir ($nu.data-dir | path join \"vendor/autoload\")
+                {rv} shell init nu | save -f ($nu.data-dir | path join \"vendor/autoload/rv.nu\")
+                {rv} shell completions nu | save --append ($nu.data-dir | path join \"vendor/autoload/rv.nu\")' | save --append $nu.config-path
+            "};
+
+            Ok(())
+        }
+    }
 }

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -30,6 +30,7 @@ use crate::commands::ruby::{RubyArgs, RubyCommand};
 use crate::commands::shell::completions::shell_completions;
 use crate::commands::shell::env::env as shell_env;
 use crate::commands::shell::init::init as shell_init;
+use crate::commands::shell::setup as shell_setup;
 use crate::commands::shell::{ShellArgs, ShellCommand};
 
 const STYLES: Styles = Styles::styled()
@@ -208,7 +209,9 @@ pub enum Error {
     #[error(transparent)]
     NonUtf8Path(#[from] FromPathBufError),
     #[error(transparent)]
-    InitError(#[from] commands::shell::init::Error),
+    Error(#[from] commands::shell::init::Error),
+    #[error(transparent)]
+    ShellError(#[from] commands::shell::Error),
     #[error(transparent)]
     EnvError(#[from] commands::shell::env::Error),
 }
@@ -324,10 +327,13 @@ async fn run_cmd(config: &Config, command: Commands) -> Result<()> {
             CacheCommand::Clean => cache_clean(config)?,
             CacheCommand::Prune => cache_prune(config)?,
         },
-        Commands::Shell(shell) => match shell.command {
-            ShellCommand::Init { shell } => shell_init(config, shell)?,
-            ShellCommand::Completions { shell } => shell_completions(&mut Cli::command(), shell),
-            ShellCommand::Env { shell } => shell_env(config, shell)?,
+        Commands::Shell(shell_args) => match shell_args.command {
+            None => shell_setup(config, shell_args.shell.unwrap())?,
+            Some(ShellCommand::Init { shell }) => shell_init(config, shell)?,
+            Some(ShellCommand::Completions { shell }) => {
+                shell_completions(&mut Cli::command(), shell)
+            }
+            Some(ShellCommand::Env { shell }) => shell_env(config, shell)?,
         },
     };
 

--- a/crates/rv/tests/integration_tests/shell.rs
+++ b/crates/rv/tests/integration_tests/shell.rs
@@ -1,0 +1,54 @@
+mod env_test;
+mod init_test;
+
+use crate::common::RvTest;
+use insta::assert_snapshot;
+
+#[test]
+fn test_zsh_succeeds() {
+    let test = RvTest::new();
+    let output = test.rv(&["shell", "zsh"]);
+    output.assert_success();
+
+    assert_snapshot!(output.normalized_stdout());
+}
+
+#[test]
+fn test_bash_succeeds() {
+    let test = RvTest::new();
+    let output = test.rv(&["shell", "bash"]);
+    output.assert_success();
+
+    assert_snapshot!(output.normalized_stdout());
+}
+
+#[test]
+fn test_fish_succeeds() {
+    let test = RvTest::new();
+    let output = test.rv(&["shell", "fish"]);
+    output.assert_success();
+
+    assert_snapshot!(output.normalized_stdout());
+}
+
+#[test]
+fn test_nu_succeeds() {
+    let test = RvTest::new();
+    let output = test.rv(&["shell", "nu"]);
+    output.assert_success();
+
+    assert_snapshot!(output.normalized_stdout());
+}
+
+#[test]
+fn test_fails_without_shell() {
+    let test = RvTest::new();
+    let output = test.rv(&["shell"]);
+    output.assert_failure();
+
+    let stderr = output.stderr();
+    assert!(
+        stderr.contains("the following required arguments were not provided:\n  <SHELL>"),
+        "shell without arguments did not print a nice error",
+    );
+}

--- a/crates/rv/tests/integration_tests/shell/mod.rs
+++ b/crates/rv/tests/integration_tests/shell/mod.rs
@@ -1,2 +1,0 @@
-mod env_test;
-mod init_test;

--- a/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__bash_succeeds.snap
+++ b/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__bash_succeeds.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rv/tests/integration_tests/shell.rs
+assertion_line: 22
+expression: output.normalized_stdout()
+---
+Install rv's shell integration into bash by running the commands below,
+or configuring your shell to do the equivalent.
+
+echo 'eval "$(/tmp/bin/rv shell init bash)"' >> ~/.bashrc
+echo 'eval "$(/tmp/bin/rv shell completions bash)"' >> ~/.bashrc

--- a/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__fish_succeeds.snap
+++ b/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__fish_succeeds.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rv/tests/integration_tests/shell.rs
+assertion_line: 31
+expression: output.normalized_stdout()
+---
+Install rv's shell integration into fish by running the commands below,
+or configuring your shell to do the equivalent.
+
+echo '/tmp/bin/rv shell init fish | source' >> ~/.config/fish/config.fish
+echo '/tmp/bin/rv shell completions fish | source' >> ~/.config/fish/config.fish

--- a/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__nu_succeeds.snap
+++ b/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__nu_succeeds.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rv/tests/integration_tests/shell.rs
+assertion_line: 40
+expression: output.normalized_stdout()
+---
+Install rv's shell integration into nu by running the commands below,
+or configuring your shell to do the equivalent.
+
+echo 'mkdir ($nu.data-dir | path join "vendor/autoload")
+/tmp/bin/rv shell init nu | save -f ($nu.data-dir | path join "vendor/autoload/rv.nu")
+/tmp/bin/rv shell completions nu | save --append ($nu.data-dir | path join "vendor/autoload/rv.nu")' | save --append $nu.config-path

--- a/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__zsh_succeeds.snap
+++ b/crates/rv/tests/integration_tests/snapshots/integration_tests__shell__zsh_succeeds.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rv/tests/integration_tests/shell.rs
+assertion_line: 13
+expression: output.normalized_stdout()
+---
+Install rv's shell integration into zsh by running the commands below,
+or configuring your shell to do the equivalent.
+
+echo 'eval "$(/tmp/bin/rv shell init zsh)"' >> ~/.zshrc
+echo 'eval "$(/tmp/bin/rv shell completions zsh)"' >> ~/.zshrc

--- a/docs/SHELL_INTEGRATION.md
+++ b/docs/SHELL_INTEGRATION.md
@@ -2,34 +2,8 @@
 
 rv integrates with [zsh](#zsh), [bash](#bash), [fish](#fish), and [nushell](#nushell).
 
-Using the configuration below, or something equivalent, will set up `rv` to automatically read any `.ruby-version` or `.tool-versions` file right before every shell command. If necessary, the shell integration will change your PATH, GEM_HOME, and other env vars as needed to ensure that the `ruby` command will run the expected version of ruby.
-
-## zsh
-
-```zsh
-echo 'eval "$(rv shell init zsh)"' >> ~/.zshrc
-echo 'eval "$(rv shell completions zsh)"' >> ~/.zshrc
-```
-
-## bash
-
-```bash
-echo 'eval "$(rv shell init bash)"' >> ~/.bashrc
-echo 'eval "$(rv shell completions bash)"' >> ~/.bashrc
-```
-
-## fish
-
-```fish
-# fish
-echo 'rv shell init fish | source' >> ~/.config/fish/config.fish
-echo 'rv shell completions fish | source' >> ~/.config/fish/config.fish
-```
-
-## nushell
-
-```nushell
-echo 'mkdir ($nu.data-dir | path join "vendor/autoload")
-rv shell init nu | save -f ($nu.data-dir | path join "vendor/autoload/rv.nu")
-rv shell completions nu | save --append ($nu.data-dir | path join "vendor/autoload/rv.nu")' | save --append $nu.config-path
-```
+Run `rv shell <zsh|bash|fish|nu>` to get instructions to set up `rv` to
+automatically read any `.ruby-version` or `.tool-versions` file right before
+every shell command. If necessary, the shell integration will change your
+PATH, GEM_HOME, and other env vars as needed to ensure that the `ruby` command
+will run the expected version of ruby.


### PR DESCRIPTION
This command prints setup instructions for each shell. The `init` and `completions` subcommands are now hidden.

Closes #239.