### PR TITLE
Add #[track_caller] to more helper fns

### DIFF
--- a/crates/rv-gem-types/src/requirement.rs
+++ b/crates/rv-gem-types/src/requirement.rs
@@ -241,10 +241,12 @@ impl FromStr for Requirement {
 mod tests {
     use super::*;
 
+    #[track_caller]
     fn v(version: &str) -> Version {
         Version::new(version).unwrap()
     }
 
+    #[track_caller]
     fn req(requirement: &str) -> Requirement {
         Requirement::parse(requirement).unwrap()
     }

--- a/crates/rv-ruby/src/request.rs
+++ b/crates/rv-ruby/src/request.rs
@@ -280,6 +280,7 @@ impl CacheKey for RubyRequest {
 mod tests {
     use super::*;
 
+    #[track_caller]
     fn v(version: &str) -> RubyRequest {
         RubyRequest::from_str(version).unwrap()
     }


### PR DESCRIPTION
This way, if the .unwrap() call panics, the error will be shown as the caller, rather than this unwrap. This helps developers figure out where the crash is happening without setting RUST_BACKTRACE=1.