### PR TITLE
Use --locked when installing

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,4 +2,4 @@
 set -euo pipefail
 set -x
 
-cargo install --path crates/rv
+cargo install --path crates/rv --locked


### PR DESCRIPTION
This way, the dependencies used when you run ./bin/install will match the versions in Cargo.lock, i.e. the same versions we run in tests etc.

This is Rust best practice.