### PR TITLE
Install git deps in parallel

### DIFF
--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -175,7 +175,9 @@ async fn ci_inner(config: &Config, args: &CiInnerArgs) -> Result<()> {
         tracing::warn!("rv ci does not support path deps yet");
     }
 
+    debug!("Downloading git deps");
     let repos = download_git_repos(lockfile.clone(), &config.cache, args)?;
+    debug!("Installing git deps");
     install_git_repos(config, repos, args).await?;
 
     debug!("Downloading gems");


### PR DESCRIPTION
I realized that our git clones are blocking, not async, so we shouldn't do them in tokio. In fact, the function shouldn't be async at all. Let's install them in parallel on the rayon thread pool.