### PR TITLE
rv ci: Handle YAML binary checksum format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,7 @@ version = "0.3.1"
 dependencies = [
  "anstream",
  "assert_fs",
+ "base64",
  "bytes",
  "bytesize",
  "camino",

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -65,6 +65,7 @@ indoc.workspace = true
 camino-tempfile = "1.4.1"
 dircpy = "0.3.19"
 glob = "0.3.3"
+base64 = "0.22.1"
 
 [dev-dependencies]
 insta = { workspace = true }


### PR DESCRIPTION
rv ci didn't handle this kind of checksum file,
which I found in the wild in https://rubygems.org/gems/options/versions/2.3.2