### PR TITLE
Run `cargo fmt` just once in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
+      - name: Run linters and formatters
         run: ./bin/lint
 
       - name: Run rv


### PR DESCRIPTION
The `bin/lint` script already runs it.