### PR TITLE
Revise the descriptions for `rv ruby` commands

### DIFF
--- a/crates/rv/src/commands/ruby.rs
+++ b/crates/rv/src/commands/ruby.rs
@@ -20,7 +20,7 @@ pub struct RubyArgs {
 
 #[derive(Subcommand)]
 pub enum RubyCommand {
-    #[command(about = "List the available Ruby installations")]
+    #[command(about = "List all installed Ruby versions")]
     List {
         /// Output format for the Ruby list
         #[arg(long, value_enum, default_value = "text")]
@@ -37,16 +37,18 @@ pub enum RubyCommand {
         version: Option<String>,
     },
 
-    #[command(about = "Show the Ruby installation directory")]
+    #[command(about = "Show the directory where all Ruby versions are installed")]
     Dir,
 
-    #[command(about = "Search for a Ruby installation")]
+    #[command(
+        about = "Show the path to the Ruby executable for the pinned version or a specific version"
+    )]
     Find {
         /// Ruby version to find
         version: Option<RubyRequest>,
     },
 
-    #[command(about = "Install a Ruby version")]
+    #[command(about = "Install the pinned Ruby version or a specific version")]
     Install {
         /// Directory to install into
         #[arg(short, long, value_name = "DIR")]
@@ -60,14 +62,17 @@ pub enum RubyCommand {
         tarball_path: Option<String>,
     },
 
-    #[command(about = "Uninstall a Ruby version")]
+    #[command(about = "Uninstall a specific Ruby version")]
     Uninstall {
         /// Ruby version to uninstall
         version: RubyRequest,
     },
 
     #[cfg(unix)]
-    #[command(about = "Run a specific Ruby", dont_delimit_trailing_values = true)]
+    #[command(
+        about = "Run Ruby with arguments, using the pinned version or a specific version",
+        dont_delimit_trailing_values = true
+    )]
     Run {
         /// By default, if your requested Ruby version isn't installed,
         /// it will be installed with `rv ruby install`'s default options.


### PR DESCRIPTION
Before:
```
  list       List the available Ruby installations
  pin        Show or set the Ruby version for the current project
  dir        Show the Ruby installation directory
  find       Search for a Ruby installation
  install    Install a Ruby version
  uninstall  Uninstall a Ruby version
  run        Run a specific Ruby
  help       Print this message or the help of the given subcommand(s)
```

After:
```
  list       List all installed Ruby versions
  pin        Show or set the Ruby version for the current project
  dir        Show the directory where all Ruby versions are installed
  find       Show the path to the Ruby executable for the pinned version or a specific version
  install    Install the pinned Ruby version or a specific version
  uninstall  Uninstall a specific Ruby version
  run        Run Ruby with arguments, using the pinned version or a specific version
  help       Print this message or the help of the given subcommand(s)
```