### PR TITLE
Fix `rv` failing to run external rubies that are not CRuby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,22 @@ jobs:
 
       - name: Build
         run: ./bin/rv --version
+
+  manage-external-rubies:
+    name: External Ruby management
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [jruby-10.0.2.0, truffleruby-33.0.0]
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+
+      - name: Install external Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Run external Ruby
+        run: bin/rv --ruby-dir "$(dirname $(dirname $(dirname $(which ruby))))" ruby run ${{ matrix.ruby }} -- --version

--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -203,7 +203,7 @@ fn extract_ruby_info(ruby_bin: &Utf8PathBuf) -> Result<Ruby, RubyError> {
     // try the full script with all features (works for most Ruby implementations)
     let full_script = r#"
         puts(Object.const_defined?(:RUBY_ENGINE) ? RUBY_ENGINE : 'ruby')
-        puts(RUBY_VERSION)
+        puts(Object.const_defined?(:RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION)
         puts(Object.const_defined?(:RUBY_PLATFORM) ? RUBY_PLATFORM : 'unknown')
         puts(Object.const_defined?(:RbConfig) && RbConfig::CONFIG['host_cpu'] ? RbConfig::CONFIG['host_cpu'] : 'unknown')
         puts(Object.const_defined?(:RbConfig) && RbConfig::CONFIG['host_os'] ? RbConfig::CONFIG['host_os'] : 'unknown')


### PR DESCRIPTION
It was saving things like `jruby-10.0.2.0` as `jruby-3.4.2`, because it was using the CRuby-compatible version instead of the actual version of the implementation.

Because of this, `rv ruby list` would list these rubies with an incorrect name, and `rv ruby run` would fail to run them when explicitly requested by their correct name.