### PR TITLE
Limit tracing to the method that can actually be slow

### DIFF
--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -59,7 +59,6 @@ pub struct Ruby {
 
 impl Ruby {
     /// Create a new Ruby instance from a directory path
-    #[instrument(skip(dir), fields(dir = %dir.as_str()), level = "trace")]
     pub fn from_dir(dir: Utf8PathBuf, managed: bool) -> Result<Self, RubyError> {
         let dir_name = dir.file_name().unwrap_or("");
 
@@ -194,7 +193,7 @@ pub enum RubyError {
 }
 
 /// Extract all Ruby information from the executable in a single call
-#[instrument(skip_all, level = "trace")]
+#[instrument(skip(ruby_bin), fields(ruby_bin = %ruby_bin.as_str()))]
 fn extract_ruby_info(ruby_bin: &Utf8PathBuf) -> Result<Ruby, RubyError> {
     if ruby_bin.as_str().ends_with("0.49/bin/ruby") {
         return ruby_049_version();

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -5,7 +5,7 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexSet;
-use tracing::{debug, instrument};
+use tracing::debug;
 
 use rv_ruby::{
     Ruby,
@@ -47,7 +47,6 @@ pub struct Config {
 }
 
 impl Config {
-    #[instrument(skip_all, level = "trace")]
     pub fn rubies(&self) -> Vec<Ruby> {
         self.discover_rubies()
     }


### PR DESCRIPTION
I think `extract_ruby_info` is the only place that could be slow because it shells out to Ruby.

This is a potential solution to #353. I added some sleeps to show the before and after (with & without ruby info cache):

#### Before

![Before](https://github.com/user-attachments/assets/011ebe95-05e5-49c0-a6a2-0e339931b4b1)

#### After

![After](https://github.com/user-attachments/assets/c06bb818-9ff1-410c-8d3d-5c2b0f0146b5)
