### PR TITLE
Fix `rv ci --gemfile`

### DIFF
--- a/crates/rv/tests/integration_tests/ci.rs
+++ b/crates/rv/tests/integration_tests/ci.rs
@@ -31,6 +31,36 @@ fn test_clean_install_download_test_gem() {
 }
 
 #[test]
+fn test_clean_install_gemfile_arg() {
+    let mut test = RvTest::new();
+
+    let releases_mock = test.mock_releases(["4.0.0"].to_vec());
+
+    // Let rv infer installation path from Gemfile argument. This test would install real gems to
+    // real rv installation directory, so we use an empty Gemfile to avoid side effects.
+    test.env.remove("BUNDLE_PATH");
+
+    let gemfile_path = test.cwd.join("Gemfile.empty");
+    let gemfile = fs_err::read_to_string("../rv-lockfile/tests/inputs/Gemfile.empty").unwrap();
+    let _ = fs_err::write(
+        gemfile_path,
+        gemfile.replace("https://rubygems.org", &test.server_url()),
+    );
+
+    let lockfile_path = test.cwd.join("Gemfile.empty.lock");
+    let lockfile =
+        fs_err::read_to_string("../rv-lockfile/tests/inputs/Gemfile.empty.lock").unwrap();
+    let _ = fs_err::write(
+        lockfile_path,
+        lockfile.replace("https://rubygems.org", &test.server_url()),
+    );
+
+    let output = test.ci(&["--gemfile", "Gemfile.empty"]);
+    output.assert_success();
+    releases_mock.assert();
+}
+
+#[test]
 fn test_clean_install_respects_ruby() {
     let mut test = RvTest::new();
 


### PR DESCRIPTION
If passed an explicit `--gemfile` parameter, `rv` would fail to infer the installation path.

This is because it asks Bundler for that (`Bundler.bundle_path`), but Bundler needs `BUNDLE_GEMFILE` set in order to respect a custom Gemfile for figuring out where to install gems. Otherwise it can't figure out what's the project root and that makes `Bundler.bundle_path` fail.