### PR TITLE
Fix `rv ci` bug when installing path gems

### DIFF
--- a/crates/rv-lockfile/tests/inputs/Gemfile.relative-gemspec-paths
+++ b/crates/rv-lockfile/tests/inputs/Gemfile.relative-gemspec-paths
@@ -1,0 +1,1 @@
+gem "foo", path: "foo"

--- a/crates/rv-lockfile/tests/inputs/Gemfile.relative-gemspec-paths.lock
+++ b/crates/rv-lockfile/tests/inputs/Gemfile.relative-gemspec-paths.lock
@@ -1,0 +1,16 @@
+PATH
+  remote: foo
+  specs:
+    foo (1.0.0)
+
+GEM
+  specs:
+
+PLATFORMS
+  universal-java-22
+
+DEPENDENCIES
+  foo!
+
+BUNDLED WITH
+   2.6.9


### PR DESCRIPTION
Any gemspecs running Ruby code depending on the cwd would fail, because the gemspecs were getting evaluated in the directory of the lockfile, not in the directory of the gemspec.