### PR TITLE
Slim `Version::normalize_version`

### DIFF
--- a/crates/rv-version/src/lib.rs
+++ b/crates/rv-version/src/lib.rs
@@ -62,7 +62,7 @@ impl Version {
             "" => Ok("0".into()),
 
             // Check for invalid characters and patterns
-            v if v.lines().count() > 1 => Err(VersionError::ContainsNewlines { version: v.into() }),
+            v if v.contains('\n') => Err(VersionError::ContainsNewlines { version: v.into() }),
             v if v.contains("..") => Err(VersionError::ConsecutiveDots { version: v.into() }),
 
             // Check for obvious junk


### PR DESCRIPTION
Uses a match to bind the trim() return, and then makes the return a little clearer since we've only got one exit via `match`.