### PR TITLE
Slim `rv ruby list`

### DIFF
--- a/crates/rv/src/commands/ruby/list.rs
+++ b/crates/rv/src/commands/ruby/list.rs
@@ -133,7 +133,7 @@ fn latest_patch_version(remote_rubies: &Vec<Ruby>) -> Vec<Ruby> {
     available_rubies.into_values().collect()
 }
 
-fn print_entries(entries: &[RubyEntry]) -> () {
+fn print_entries(entries: &[RubyEntry]) {
     let width = entries
         .iter()
         .map(|e| e.ruby.display_name().len())


### PR DESCRIPTION
I'm seeing some differences in the test output where we'll mark different Ruby versions as active that the old implementation didn't so I'm not sure if this is worth pursuing further.