### PR TITLE
Fix race condition during `rv ci` when installing gemspecs

### DIFF
--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -1464,7 +1464,7 @@ fn convert_gemspec_yaml_to_ruby(config: &Config, contents: String) -> Result<Str
         &config.ruby_request(),
         &[
             "-e",
-            "Gem.load_yaml; print Gem::SafeYAML.safe_load(ARGF.read).to_ruby",
+            "Gem.discover_gems_on_require = false; Gem.load_yaml; print Gem::SafeYAML.safe_load(ARGF.read).to_ruby",
             temp_path.as_str(),
         ],
         CaptureOutput::Both,


### PR DESCRIPTION
If the lockfile being installed depends on psych, it can happen that when installing a gemspec and shelling out to Ruby in order to convert it into Ruby, RubyGems activates the version of psych in the lockfile. If it happens to be only "half installed" in that moment, the Rub process will crash like this:

```
    × Error converting YAML gemspec to Ruby: /path/to/.local/share/rv/gems/ruby/3.2.4/gems/psych-5.2.0/lib/psych.rb:2:in `require_relative': cannot load such file -- /path/
    │ to/.local/share/rv/gems/ruby/3.2.4/gems/psych-5.2.0/lib/psych/versions (LoadError)
    │     from /path/to/.local/share/rv/gems/ruby/3.2.4/gems/psych-5.2.0/lib/psych.rb:2:in `<top (required)>'
    │     from <internal:/path/to/.local/share/rv/rubies/ruby-3.2.4/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
    │     from <internal:/path/to/.local/share/rv/rubies/ruby-3.2.4/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
    │     from /path/to/.local/share/rv/rubies/ruby-3.2.4/lib/ruby/3.2.0/rubygems.rb:609:in `load_yaml'
    │     from -e:1:in `<main>'
    │
```

The ideal solution (see TODO above the modified function) is to not rely in Ruby for this conversion but as a stopgap, a solution is to force RubyGems to use the version of psych that comes with Ruby instead of the version that we're in the middle of installing.