### PR TITLE
Improve `rv ci` summary and progress log

### DIFF
--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -266,28 +266,28 @@ async fn ci_inner_work(config: &Config, args: &CiInnerArgs, progress: &WorkProgr
 
     println!("Summary:");
     println!(
-        " - {} gem packages fetched: {} cached, {} downloaded ({})",
+        " - {} fetching {} gem packages: {} cached, {} downloaded",
+        format_duration(download_elapsed),
         downloaded_count,
         cached_count,
         network_count,
-        format_duration(download_elapsed)
     );
     println!(
-        " - {} gems installed: {} from gem packages, {} from git repos, {} from local paths ({})",
+        " - {} installing {} gems: {} from gem packages, {} from git repos, {} from local paths",
+        format_duration(install_elapsed),
         package_count + git_count + path_count,
         package_count,
         git_count,
         path_count,
-        format_duration(install_elapsed)
     );
     if compiled_count > 0 {
         println!(
-            " - {} native extensions compiled ({})",
+            " - {} compiling {} native extensions",
+            format_duration(compile_elapsed),
             compiled_count,
-            format_duration(compile_elapsed)
         );
     }
-    println!(" - {} total elapsed time", format_duration(total_elapsed));
+    println!(" - {} total", format_duration(total_elapsed));
 
     Ok(())
 }


### PR DESCRIPTION
By including git and path gem information.

For example, running `rv ci` against the huginn lockfile, we used to print this summary:

```
Summary:
 - 292 gems fetched: 292 cached, 0 downloaded (0.1s)
 - 292 gems installed (3.4s)
 - 29 native extensions compiled (11.0s)
 - 14.5s total elapsed time
```

Now it's like this:

```
Summary:
 - 292 gems fetched: 292 cached, 0 downloaded (0.1s)
 - 303 gems installed: 292 from gem servers, 10 from git repos, 1 from local paths (5.3s)
 - 29 native extensions compiled (10.9s)
 - 16.3s total elapsed time
```

I also changed the "Resolving gems" message to separate "Installing path gems" and "Downloading and installing git gems", because I think "Resolving gems" is confusing because we usually say that when resolving versions of gems (via PubGrub, etc) and `rv ci` already has a resolution of gem versions available (the lockfile), so no work to do there.

Setting as draft for now because I'd like to move forward with #369 first and because I want to polish it a bit.
