### PR TITLE
rv-version: Add next_major and next_minor methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,7 @@ dependencies = [
 name = "rv-version"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "thiserror",
 ]
 

--- a/crates/rv-version/Cargo.toml
+++ b/crates/rv-version/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
These will be used for `rv tool install`, specifically for finding the upper bound on requirements like
 `~> 1.2.3` or `~> 0.3`