### PR TITLE
Bugfix: rv tool install always thought tool was already installed

### DIFF
--- a/crates/rv/src/commands/tool/install.rs
+++ b/crates/rv/src/commands/tool/install.rs
@@ -98,7 +98,7 @@ pub async fn install(config: &Config, gem: GemName, gem_server: String, force: b
 
     // Check if the tool was already installed.
     let install_path = super::tool_dir(&args.gem, &version_to_install.version);
-    let already_installed = fs::exists(&install_path).is_ok();
+    let already_installed = fs::exists(&install_path).unwrap_or_default();
     if already_installed {
         if force {
             debug!("Reinstalling tool");


### PR DESCRIPTION
I just checked that `exists` succeeded, not that it succeeded AND RETURNED TRUE oops