### PR TITLE
Remove baseline job from CI smoke tests

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   smoke-test:
-    name: ${{ matrix.project }}-rv
+    name: ${{ matrix.project }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,88 +32,3 @@ jobs:
 
       - name: rv clean-install for ${{ matrix.project }}
         run: bin/smoke-tests/${{ matrix.project }}
-
-  baseline:
-    name: ${{ matrix.project }}-baseline
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - project: diaspora
-            repo: https://github.com/diaspora/diaspora.git
-            deps: >-
-              build-essential git ca-certificates cmake pkg-config
-              libyaml-dev libffi-dev libxml2-dev libxslt-dev libpq-dev
-              default-libmysqlclient-dev libcurl4-openssl-dev libyajl-dev
-              libmagickwand-dev libgit2-dev libssh2-1-dev libidn-dev
-          - project: discourse
-            repo: https://github.com/discourse/discourse.git
-            ruby-version: "3.3"
-            deps: >-
-              build-essential git ca-certificates pkg-config
-              libyaml-dev libpq-dev libxml2-dev libxslt-dev
-              zlib1g-dev libsqlite3-dev
-          - project: fastlane
-            repo: https://github.com/fastlane/fastlane.git
-            deps: >-
-              build-essential git ca-certificates
-              libyaml-dev libffi-dev libssl-dev
-            setup: echo "3.3" > .ruby-version
-          - project: gitlab
-            repo: https://gitlab.com/gitlab-org/gitlab.git
-            deps: >-
-              build-essential git ca-certificates pkg-config cmake
-              libyaml-dev libre2-dev libffi-dev libxml2-dev libxslt-dev
-              libcurl4-openssl-dev libicu-dev libkrb5-dev libpq-dev
-              libpcre2-dev libgpgme-dev zlib1g-dev
-          - project: homebrew
-            repo: https://github.com/Homebrew/brew.git
-            workdir: homebrew/Library/Homebrew
-            deps: >-
-              build-essential git ca-certificates
-              libffi-dev libyaml-dev python3-dev
-          - project: huginn
-            repo: https://github.com/huginn/huginn.git
-            ruby-version: "3.3"
-            deps: >-
-              build-essential git ca-certificates
-              libyaml-dev libffi-dev libxml2-dev libxslt-dev libpq-dev
-              default-libmysqlclient-dev libcurl4-openssl-dev libsqlite3-dev
-          - project: lobsters
-            repo: https://github.com/lobsters/lobsters.git
-            deps: >-
-              build-essential git ca-certificates
-              libyaml-dev libmariadb-dev libsqlite3-dev
-          - project: mastodon
-            repo: https://github.com/mastodon/mastodon.git
-            deps: >-
-              build-essential git ca-certificates
-              libyaml-dev libpq-dev libicu-dev libidn-dev
-              libxml2-dev libxslt1-dev zlib1g-dev libpam0g-dev
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v6
-
-      - name: Clone ${{ matrix.project }}
-        run: git clone --depth 1 ${{ matrix.repo }} ${{ matrix.project }}
-
-      - name: Install native dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ${{ matrix.deps }}
-
-      - name: Project setup
-        if: matrix.setup
-        working-directory: ${{ matrix.workdir || matrix.project }}
-        run: ${{ matrix.setup }}
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          working-directory: ${{ matrix.workdir || matrix.project }}
-          ruby-version: ${{ matrix.ruby-version || '' }}
-
-      - name: Run bundle install
-        working-directory: ${{ matrix.workdir || matrix.project }}
-        run: bundle install


### PR DESCRIPTION
Per #366, these baseline runs should actually be _benchmark_ runs, which we can do as a separate task later on.

For now, this will clean up the Smoke Tests CI view, and show us what we really want to see in there, which is `rv` working as expected for popular Ruby projects.