### PR TITLE
Run clippy before fmt

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -2,11 +2,11 @@
 set -euo pipefail
 set -x
 
+cargo clippy --all-targets --all-features "$@" -- -D warnings
+
 if [ $# -gt 0 ] && [ "$1" = "--fix" ]
 then
   cargo fmt --all
 else
   cargo fmt --all -- --check
 fi
-
-cargo clippy --all-targets --all-features "$@" -- -D warnings


### PR DESCRIPTION
This fixes 2 issues:

* Sometimes fmt fixes a style issue, but then clippy fixes a lint issue, creating a style issue again, requiring another fmt pass.
* Clippy will refuse to run on a dirty worktree, and sometimes fmt will get it dirty.

Running fmt in the end should fix both problems.