### PR TITLE
Fix issue making some native extensions skipped by `rv ci`

### DIFF
--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -858,10 +858,10 @@ fn compile_gems(
     }
 
     for spec in &specs {
-        if let Some(gem) = nodes.get_mut(&spec.name) {
+        if nodes.contains_key(&spec.name) {
             for dep in &spec.dependencies {
-                if dep.is_runtime() {
-                    gem.add_dep(dep.name.clone());
+                if nodes.contains_key(&dep.name) && dep.is_runtime() {
+                    nodes.get_mut(&spec.name).unwrap().add_dep(dep.name.clone());
                 }
             }
         }


### PR DESCRIPTION
When creating a dependency graph for native extensions so that they all get built before their dependant gems, we were including dependencies _without_ native extensions as dependencies of those graph nodes.

This was causing the gems with these non-native dependencies to never get visited because their dependencies would never be visited either themselves since they were not nodes of the graph.