### PR TITLE
Separate VersionPlatform out of GemRelease

### DIFF
--- a/crates/rv-gem-types/src/lib.rs
+++ b/crates/rv-gem-types/src/lib.rs
@@ -3,6 +3,7 @@ pub mod name_tuple;
 pub mod platform;
 pub mod requirement;
 pub mod specification;
+pub mod version_platform;
 
 pub use dependency::{Dependency, DependencyError, DependencyType};
 pub use name_tuple::{NameTuple, NameTupleError};
@@ -10,3 +11,4 @@ pub use platform::Platform;
 pub use requirement::{ComparisonOperator, Requirement, VersionConstraint};
 pub use rv_version::{Version, VersionError};
 pub use specification::{Specification, SpecificationError};
+pub use version_platform::{VersionPlatform, VersionPlatformError};

--- a/crates/rv-gem-types/src/platform.rs
+++ b/crates/rv-gem-types/src/platform.rs
@@ -1,7 +1,6 @@
 use current_platform::CURRENT_PLATFORM;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rv_version::Version;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, str::FromStr};
 
@@ -329,19 +328,12 @@ impl FromStr for Platform {
     }
 }
 
-/// Splits a gem version with a platform suffix, like `1.11.0.rc1-x86_64-linux`,
-/// into its version and platform components.
-pub fn version_platform_split(s: &str) -> Option<(Version, Platform)> {
-    let (v, p) = s.split_once('-').unwrap_or((s, "ruby"));
-
-    let version = Version::new(v).ok()?;
-    let platform = Platform::new(p).ok()?;
-
-    Some((version, platform))
-}
-
 #[cfg(test)]
 mod tests {
+    use rv_version::Version;
+
+    use crate::VersionPlatform;
+
     use super::*;
 
     #[test]
@@ -936,7 +928,7 @@ mod tests {
         ];
 
         for (input, (expected_version, expected_platform)) in test_cases {
-            let (version, platform) = version_platform_split(input).unwrap();
+            let VersionPlatform { version, platform } = input.parse().unwrap();
             assert_eq!(version, Version::new(expected_version).unwrap());
             assert_eq!(platform, Platform::new(expected_platform).unwrap());
         }

--- a/crates/rv-gem-types/src/version_platform.rs
+++ b/crates/rv-gem-types/src/version_platform.rs
@@ -1,0 +1,61 @@
+use std::str::FromStr;
+
+use rv_version::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::Platform;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionPlatform {
+    pub version: Version,
+    pub platform: Platform,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VersionPlatformError {
+    #[error(transparent)]
+    Version(#[from] rv_version::VersionError),
+    #[error(transparent)]
+    Platform(#[from] crate::platform::PlatformError),
+}
+
+/// Splits a gem version with a platform suffix, like `1.11.0.rc1-x86_64-linux`,
+/// into its version and platform components.
+impl FromStr for VersionPlatform {
+    type Err = VersionPlatformError;
+
+    /// Splits a gem version with a platform suffix, like `1.11.0.rc1-x86_64-linux`,
+    /// into its version and platform components.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (v, p) = s.split_once('-').unwrap_or((s, "ruby"));
+
+        let version = Version::new(v)?;
+        let platform = Platform::new(p)?;
+
+        Ok(VersionPlatform { version, platform })
+    }
+}
+
+impl std::fmt::Display for VersionPlatform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.platform {
+            Platform::Ruby => write!(f, "{}", self.version),
+            _ => write!(f, "{}-{}", self.version, self.platform),
+        }
+    }
+}
+
+impl Ord for VersionPlatform {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Sort by version, then platform
+        self.version
+            .cmp(&other.version)
+            .then_with(|| self.platform.cmp(&other.platform))
+    }
+}
+
+impl PartialOrd for VersionPlatform {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/rv/src/commands/ci.rs
+++ b/crates/rv/src/commands/ci.rs
@@ -13,6 +13,7 @@ use rayon::ThreadPoolBuildError;
 use regex::Regex;
 use reqwest::Client;
 use rv_gem_types::Specification as GemSpecification;
+use rv_gem_types::VersionPlatform;
 use rv_lockfile::datatypes::ChecksumAlgorithm;
 use rv_lockfile::datatypes::GemSection;
 use rv_lockfile::datatypes::GemVersion;
@@ -1551,8 +1552,9 @@ async fn download_gem_source<'i>(
     let gems_to_download = gem_source.specs.into_iter().filter(|spec| {
         // Failing to parse a locked spec is most likely because of some manual edition, panicking
         // in that case seems fine for now, so unwrap the result freely
-        let (_version, plat) =
-            rv_gem_types::platform::version_platform_split(spec.gem_version.version).unwrap();
+        let plat = VersionPlatform::from_str(spec.gem_version.version)
+            .unwrap()
+            .platform;
         plat.is_local()
     });
     let spec_stream = futures_util::stream::iter(gems_to_download);

--- a/crates/rv/src/commands/tool/install/pubgrub_bridge.rs
+++ b/crates/rv/src/commands/tool/install/pubgrub_bridge.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use pubgrub::{OfflineDependencyProvider, Ranges, SelectedDependencies};
-use rv_gem_types::{Platform, Version};
+use rv_gem_types::{Platform, Version, VersionPlatform};
 use rv_lockfile::datatypes::SemverConstraint;
 
 use super::{
@@ -15,23 +15,23 @@ pub fn solve(
     gem_info: HashMap<GemName, Vec<GemRelease>>,
 ) -> Result<SelectedDependencies<DepProvider>, pubgrub::PubGrubError<DepProvider>> {
     let provider = all_dependencies(gem_info);
-    pubgrub::resolve(&provider, gem, release)
+    pubgrub::resolve(&provider, gem, release.version_platform)
 }
 
-pub type DepProvider = OfflineDependencyProvider<GemName, Ranges<GemRelease>>;
+pub type DepProvider = OfflineDependencyProvider<GemName, Ranges<VersionPlatform>>;
 
 /// Build a PubGrub "dependency provider", i.e. something that can be queried
 /// with all the information of a GemServer (which gems are available, what versions that gem has,
 /// and what dependencies that gem-version pair has).
 /// This is really just taking the `gem_info` hashmap and organizing it in a way that PubGrub can understand.
 fn all_dependencies(gem_info: HashMap<GemName, Vec<GemRelease>>) -> DepProvider {
-    let mut m: OfflineDependencyProvider<GemName, Ranges<GemRelease>> =
+    let mut m: OfflineDependencyProvider<GemName, Ranges<VersionPlatform>> =
         OfflineDependencyProvider::new();
     for (package, gem_releases) in gem_info {
         for gem_release in gem_releases {
             m.add_dependencies(
                 package.clone(),
-                gem_release.clone(),
+                gem_release.version_platform,
                 gem_release
                     .deps
                     .into_iter()
@@ -42,19 +42,17 @@ fn all_dependencies(gem_info: HashMap<GemName, Vec<GemRelease>>) -> DepProvider 
     m
 }
 
-impl From<VersionConstraint> for Ranges<GemRelease> {
+impl From<VersionConstraint> for Ranges<VersionPlatform> {
     fn from(constraint: VersionConstraint) -> Self {
         let v = constraint.version;
-        let min_v = GemRelease {
+        let min_v = VersionPlatform {
             version: v.clone(),
             platform: Platform::Ruby,
-            ..GemRelease::default()
         };
 
-        let max_v = GemRelease {
+        let max_v = VersionPlatform {
             version: v.clone(),
             platform: Platform::Current,
-            ..GemRelease::default()
         };
 
         match constraint.constraint_type {
@@ -73,10 +71,9 @@ impl From<VersionConstraint> for Ranges<GemRelease> {
             SemverConstraint::LessThanOrEqual => Ranges::lower_than(max_v),
             // This one is weird, but at least it's encapsulated into a `bump` method.
             SemverConstraint::Pessimistic => {
-                let bump_v = GemRelease {
+                let bump_v = VersionPlatform {
                     version: Version::new(format!("{}.A", v.bump())).unwrap(),
                     platform: Platform::Ruby,
-                    ..GemRelease::default()
                 };
 
                 Ranges::intersection(
@@ -88,7 +85,7 @@ impl From<VersionConstraint> for Ranges<GemRelease> {
     }
 }
 
-impl From<VersionConstraints> for Ranges<GemRelease> {
+impl From<VersionConstraints> for Ranges<VersionPlatform> {
     fn from(constraints: VersionConstraints) -> Self {
         // Convert the RubyGems constraints into PubGrub ranges.
         let ranges = constraints.inner.into_iter().map(Ranges::from);
@@ -105,16 +102,21 @@ impl From<VersionConstraints> for Ranges<GemRelease> {
 
 #[cfg(test)]
 mod tests {
+    use serde::{Deserialize, Serialize};
+
     use super::*;
     use crate::commands::tool::install::gemserver::VersionConstraint;
+    use std::str::FromStr;
+
+    fn vp(input: &str) -> VersionPlatform {
+        VersionPlatform::from_str(input).unwrap()
+    }
 
     fn r(input: &str) -> GemRelease {
-        let (version, platform) = rv_gem_types::platform::version_platform_split(input).unwrap();
-
         GemRelease {
-            version,
-            platform,
-            ..GemRelease::default()
+            version_platform: VersionPlatform::from_str(input).unwrap(),
+            deps: Default::default(),
+            metadata: Default::default(),
         }
     }
 
@@ -123,7 +125,7 @@ mod tests {
     fn test_mapping() {
         struct Test {
             input: Vec<VersionConstraint>,
-            expected: Ranges<GemRelease>,
+            expected: Ranges<VersionPlatform>,
         }
         #[expect(clippy::single_element_loop)] // Remove this 'expect' if you add another test.
         for Test { input, expected } in [Test {
@@ -132,8 +134,8 @@ mod tests {
                 version: "3.0.3".parse().unwrap(),
             }],
             expected: Ranges::intersection(
-                &Ranges::higher_than(r("3.0.3")),
-                &Ranges::strictly_lower_than(r("3.1.A")),
+                &Ranges::higher_than(vp("3.0.3")),
+                &Ranges::strictly_lower_than(vp("3.1.A")),
             ),
         }] {
             // Take the Ruby gem version requirements,
@@ -145,10 +147,39 @@ mod tests {
 
     #[test]
     fn test_resolution() {
-        let gem_info: HashMap<String, Vec<GemRelease>> = serde_json::from_str(include_str!(
+        /// All the information about a release of a gem available on some Gemserver.
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        pub struct PrevGemRelease {
+            pub version: Version,
+            pub platform: Platform,
+            pub deps: Vec<crate::commands::tool::install::gemserver::Dep>,
+            pub metadata: crate::commands::tool::install::gemserver::Metadata,
+        }
+
+        impl From<PrevGemRelease> for GemRelease {
+            fn from(prev: PrevGemRelease) -> Self {
+                let PrevGemRelease {
+                    version,
+                    platform,
+                    deps,
+                    metadata,
+                } = prev;
+                GemRelease {
+                    version_platform: VersionPlatform { version, platform },
+                    deps,
+                    metadata,
+                }
+            }
+        }
+
+        let gem_info: HashMap<String, Vec<PrevGemRelease>> = serde_json::from_str(include_str!(
             "../../../../testdata/all_nokogiri_transitive_deps.json"
         ))
         .unwrap();
+        let gem_info: HashMap<String, Vec<GemRelease>> = gem_info
+            .into_iter()
+            .map(|(k, releases)| (k, releases.into_iter().map(GemRelease::from).collect()))
+            .collect();
         let mut out: Vec<_> = solve("nokogiri".to_owned(), r("1.19.0-arm64-darwin"), gem_info)
             .unwrap()
             .into_iter()

--- a/crates/rv/src/commands/tool/install/snapshots/rv__commands__tool__install__gemserver__tests__body_parser.snap
+++ b/crates/rv/src/commands/tool/install/snapshots/rv__commands__tool__install__gemserver__tests__body_parser.snap
@@ -4,21 +4,23 @@ expression: actual_parsed_response
 ---
 [
     GemRelease {
-        version: Version {
-            version: "2.2.2",
-            segments: [
-                Number(
-                    2,
-                ),
-                Number(
-                    2,
-                ),
-                Number(
-                    2,
-                ),
-            ],
+        version_platform: VersionPlatform {
+            version: Version {
+                version: "2.2.2",
+                segments: [
+                    Number(
+                        2,
+                    ),
+                    Number(
+                        2,
+                    ),
+                    Number(
+                        2,
+                    ),
+                ],
+            },
+            platform: Ruby,
         },
-        platform: Ruby,
         deps: [
             actionmailer@[= 2.2.2],
             actionpack@[= 2.2.2],
@@ -34,21 +36,23 @@ expression: actual_parsed_response
         },
     },
     GemRelease {
-        version: Version {
-            version: "2.3.2",
-            segments: [
-                Number(
-                    2,
-                ),
-                Number(
-                    3,
-                ),
-                Number(
-                    2,
-                ),
-            ],
+        version_platform: VersionPlatform {
+            version: Version {
+                version: "2.3.2",
+                segments: [
+                    Number(
+                        2,
+                    ),
+                    Number(
+                        3,
+                    ),
+                    Number(
+                        2,
+                    ),
+                ],
+            },
+            platform: Ruby,
         },
-        platform: Ruby,
         deps: [
             actionmailer@[= 2.3.2],
             actionpack@[= 2.3.2],

--- a/crates/rv/src/commands/tool/install/transitive_dep_query.rs
+++ b/crates/rv/src/commands/tool/install/transitive_dep_query.rs
@@ -45,7 +45,7 @@ pub(crate) async fn query_all_gem_deps(
         format!(
             "{}_{}_{}.json",
             gemserver.url.host_str().unwrap_or_default(),
-            root.version,
+            root.version(),
             root_gem_name
         ),
     );


### PR DESCRIPTION
As discussed in https://github.com/spinel-coop/rv/pull/428#discussion_r2734595695:

I don't think we should use GemRelease as the version here. I think instead we should make a new type struct VersionPlatform{version: Version, platform: Platform} which should be the type of version that pubgrub resolves here.

Why? Because it makes GemRelease implement a bunch of awkward traits, like Ord and Display, that are really properties of the pair (version, platform). We never need to display the entire GemRelease as a string, we never need to order or compare the GemRelease's metadata or platform, etc.

It just really feels like the (version, platform) pair is a special unit within the GemRelease type, and should be broken into its own type -- it's meaningful independent of the GemRelease struct.