### PR TITLE
Improve errors when failing to parse yaml gemspecs

### DIFF
--- a/crates/rv/src/commands/ci/checksums.rs
+++ b/crates/rv/src/commands/ci/checksums.rs
@@ -1,5 +1,5 @@
-use super::Error;
-use super::Result;
+use super::UnpackError;
+use super::UnpackResult;
 use std::io::{self, Read};
 
 use bytes::Bytes;
@@ -117,14 +117,14 @@ impl ArchiveChecksums {
         Some(out)
     }
 
-    pub fn validate_data_tar(&self, gem_name: String, hashed: &Hashed) -> Result<()> {
+    pub fn validate_data_tar(&self, gem_name: String, hashed: &Hashed) -> UnpackResult<()> {
         if self.sha256.is_none() && self.sha512.is_none() {
             eprintln!("Checksum file for {gem_name} was empty");
         }
         if let Some(sha256) = &self.sha256
             && hashed.digest_256 != sha256.data_tar_gz
         {
-            return Err(Error::ArchiveChecksumFail {
+            return Err(UnpackError::ArchiveChecksumFail {
                 filename: "data.tar.gz".to_owned(),
                 gem_name,
                 algo: "sha256",
@@ -133,7 +133,7 @@ impl ArchiveChecksums {
         if let Some(sha512) = &self.sha512
             && hashed.digest_512 != sha512.data_tar_gz
         {
-            return Err(Error::ArchiveChecksumFail {
+            return Err(UnpackError::ArchiveChecksumFail {
                 filename: "data.tar.gz".to_owned(),
                 gem_name,
                 algo: "sha512",
@@ -142,14 +142,14 @@ impl ArchiveChecksums {
         Ok(())
     }
 
-    pub fn validate_metadata(&self, gem_name: String, hashed: Hashed) -> Result<()> {
+    pub fn validate_metadata(&self, gem_name: String, hashed: Hashed) -> UnpackResult<()> {
         if self.sha256.is_none() && self.sha512.is_none() {
             eprintln!("Checksum file for {gem_name} was empty");
         }
         if let Some(sha256) = &self.sha256 {
             let expected = &sha256.metadata_gz;
             if hashed.digest_256 != expected {
-                return Err(Error::ArchiveChecksumFail {
+                return Err(UnpackError::ArchiveChecksumFail {
                     filename: "metadata.gz".to_owned(),
                     gem_name,
                     algo: "sha256",
@@ -159,7 +159,7 @@ impl ArchiveChecksums {
         if let Some(sha512) = &self.sha512
             && hashed.digest_512 != sha512.metadata_gz
         {
-            return Err(Error::ArchiveChecksumFail {
+            return Err(UnpackError::ArchiveChecksumFail {
                 filename: "metadata.gz".to_owned(),
                 gem_name,
                 algo: "sha512",


### PR DESCRIPTION
Improves two things:

* If `rv tool install` fails due to failing to parse a YAML file, it will leave no side effects, and it will fail in the same way when running it a second time. Before this PR, it will "succeed" when run the second time with:

      $ rv tool install cssminify
      cssminify 1.0.2 already installed at /path/to/.local/share/rv/tools/cssminify@1.0.2

* If `rv tool install` fails due to failing to parse a YAML file, it will no longer claim the reason was that it could not find a gemspec in a certain path, nor give a warning about a `.gemspec` file having invalid YAML (gemspec files have no YAML):

    ### Before
      
      $ rv tool install cssminify
      Installing gem packages 0/1
      Warning: gem specification at /path/to/.local/share/rv/tools/cssminify@1.0.2/specifications/cssminify-1.0.2.gemspec was invalid: YAML parsing error
        × No gemspec found for downloaded gem cssminify-1.0.2
        
    ### After
    
      $ rv tool install cssminify
      Installing gem packages 0/1
        × Could not parse YAML metadata inside gem package

I wanted to also print proper miette parsing diagnostics in order to further help fixing #429, but I couldn't figure out how to do it.
