### PR TITLE
Tweak `tool install` not found error message

### DIFF
--- a/crates/rv/src/commands/tool/install.rs
+++ b/crates/rv/src/commands/tool/install.rs
@@ -33,7 +33,7 @@ type GemName = String;
 pub enum Error {
     #[error("{0} is not a valid URL")]
     BadUrl(String),
-    #[error("No gem with that name ({gem_name}) exists on the server {server}")]
+    #[error("{gem_name} doesn't exist on {server}")]
     NotFound { gem_name: String, server: String },
     #[error("No version {0} available")]
     NoVersionFound(GemVersion),


### PR DESCRIPTION
The error message appears when we've just tried to install a specific gem env, so I don't think we need to say gem and server.

Before:

```
$ rv tool install bahhumbug
  × No gem with that name (bahhumbug) exists on the server https://gem.coop/
```

After:

```
$ rv tool install bahhumbug
  × bahhumbug doesn't exist on https://gem.coop/
```