### PR TITLE
Switch GemNotFound to a more technical wording

### DIFF
--- a/crates/rv/src/commands/tool/install/gemserver.rs
+++ b/crates/rv/src/commands/tool/install/gemserver.rs
@@ -19,8 +19,8 @@ pub struct Gemserver {
 pub enum Error {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
-    #[error("The requested gem {gem} was not found on the RubyGems server {gem_server}")]
-    GemNotFound { gem: GemName, gem_server: Url },
+    #[error("The url {url} unexpectedly returned an empty response")]
+    EmptyResponse { url: Url },
 }
 
 impl Gemserver {
@@ -45,9 +45,8 @@ impl Gemserver {
             .text()
             .await?;
         if index_body.is_empty() {
-            return Err(Error::GemNotFound {
-                gem: gem.to_owned(),
-                gem_server: self.url.to_owned(),
+            return Err(Error::EmptyResponse {
+                url: self.url.to_owned(),
             });
         }
         Ok(index_body)


### PR DESCRIPTION
It doesn't seem possible to trigger this directly, at least with rg.org/gem.coop because `/info/<name>` will respond with 404 if the gem does not exist, and they will never serve dependency information for names not in the server anyways, so we should never be requesting the `/info/<name>` endpoint for a gem that does not exist.

So changing that error to a more technical wording that more strongly suggests that something was really unexpected, on the server side.