### PR TITLE
Additional fixtures for parallel compilation deps bug

### DIFF
--- a/crates/rv-lockfile/tests/inputs/Gemfile.llhttp-ffi
+++ b/crates/rv-lockfile/tests/inputs/Gemfile.llhttp-ffi
@@ -11,4 +11,4 @@
 # potentially compile after llhttp-ffi (which needs ffi to be ready).
 
 source "https://rubygems.org"
-gem "llhttp-ffi"
+gem "llhttp-ffi", "0.4.0"

--- a/crates/rv-lockfile/tests/inputs/Gemfile.llhttp-ffi.lock
+++ b/crates/rv-lockfile/tests/inputs/Gemfile.llhttp-ffi.lock
@@ -5,7 +5,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
-    llhttp-ffi (0.5.1)
+    llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     rake (13.3.1)
@@ -14,12 +14,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  llhttp-ffi
+  llhttp-ffi (= 0.4.0)
 
 CHECKSUMS
   ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
   ffi-compiler (1.3.2) sha256=a94f3d81d12caf5c5d4ecf13980a70d0aeaa72268f3b9cc13358bcc6509184a0
-  llhttp-ffi (0.5.1) sha256=9a25a7fc19311f691a78c9c0ac0fbf4675adbd0cca74310228fdf841018fa7bc
+  llhttp-ffi (0.4.0) sha256=e5f7327db3cf8007e648342ef76347d6e0ae545a8402e519cca9c886eb37b001
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
 
 BUNDLED WITH


### PR DESCRIPTION
This is detailed in #452.

This PR adds a `llhttp-ffi` fixture for parallel compilation test coverage, which was fixed in #442.