### PR TITLE
Remove tweaks to disable indicatif

### DIFF
--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -321,13 +321,10 @@ async fn run() -> Result<()> {
         } else {
             None
         })
-        .with(filter);
+        .with(filter)
+        .with(indicatif_layer);
 
-    if std::env::var("RV_DISABLE_INDICATIF").is_ok() || matches!(cli.command, Commands::Shell(_)) {
-        reg.init();
-    } else {
-        reg.with(indicatif_layer).init();
-    }
+    reg.init();
 
     let config = cli.config()?;
     run_cmd(&config, cli.command).await

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -40,7 +40,6 @@ impl RvTest {
         test.env.insert("HOME".into(), test.temp_home().into());
         test.env
             .insert("BUNDLE_PATH".into(), test.cwd.join("app").into());
-        test.env.insert("RV_DISABLE_INDICATIF".into(), "1".into()); // Disable indicatif progress bars in tests due to a bug in tracing-indicatif
 
         // Disable network requests by default
         test.env.insert(


### PR DESCRIPTION
I _think_ we no longer need any of this since https://github.com/spinel-coop/rv/pull/350/changes/22e1dab5eb1d008c45a1b4b6d2f796ddd38339a6 and https://github.com/spinel-coop/rv/pull/357/changes/587819b403734afda5a1964bfd8085ae558be355.

If we ever start logging some informative message when scanning ruby information by default, we'll need to handle that manually anyways to not print anything when running `rv shell`.

References https://github.com/spinel-coop/rv/pull/352#issuecomment-3770423472.