### PR TITLE
New flag for list all available versions of ruby.

### DIFF
--- a/crates/rv/src/commands/ruby.rs
+++ b/crates/rv/src/commands/ruby.rs
@@ -19,19 +19,14 @@ pub struct RubyArgs {
 
 #[derive(Subcommand)]
 pub enum RubyCommand {
-    #[command(about = "List all installed Ruby versions")]
+    #[command(about = "List all installed and available Ruby versions")]
     List {
         /// Output format for the Ruby list
         #[arg(long, value_enum, default_value = "text")]
         format: OutputFormat,
 
-        /// Show only installed Ruby versions
-        #[arg(long)]
-        installed_only: bool,
-
-        /// Show all available Ruby versions, including outdated ones
-        #[arg(long)]
-        list_all: bool,
+        #[command(flatten)]
+        version_filter: list::VersionFilter,
     },
 
     #[command(about = "Show or set the Ruby version for the current project")]

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -331,9 +331,8 @@ async fn run_cmd(config: &Config, command: Commands) -> Result<()> {
             RubyCommand::Find { version } => ruby_find(config, version)?,
             RubyCommand::List {
                 format,
-                installed_only,
-                list_all,
-            } => ruby_list(config, format, installed_only, list_all).await?,
+                version_filter,
+            } => ruby_list(config, format, version_filter).await?,
             RubyCommand::Pin { version } => ruby_pin(config, version)?,
             RubyCommand::Dir => ruby_dir(config),
             RubyCommand::Install {


### PR DESCRIPTION
Hi! I really like this project, manage and install Ruby versions always was a problem.

I just switched from rbenv and I notice that there was no flag for list all available ruby versions (Including outdated) that I can install like:
```bash
rbenv install --list-all
```

So I added a new flag to the list command:

```bash
rv ruby list --list-all
```
Sorry, I didn't know how to test it and I don't want to modify much code.

Let me know any comment or feel free to close the PR.