### PR TITLE
Consistent behavior when there's no user HOME

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,27 +738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,12 +1706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,17 +2093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,7 +2324,6 @@ dependencies = [
  "sevenz-rust2",
  "sha2",
  "shell-escape",
- "shellexpand",
  "tabled",
  "tar",
  "tempfile",
@@ -2419,6 +2380,7 @@ dependencies = [
  "flate2",
  "insta",
  "miette",
+ "rv-dirs",
  "rv-gem-specification-yaml",
  "rv-gem-types",
  "saphyr",
@@ -2483,6 +2445,7 @@ dependencies = [
  "once_cell",
  "regex",
  "rv-cache",
+ "rv-dirs",
  "serde",
  "serde_with",
  "thiserror",
@@ -2710,15 +2673,6 @@ name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
-
-[[package]]
-name = "shellexpand"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
-dependencies = [
- "dirs",
-]
 
 [[package]]
 name = "shlex"

--- a/crates/rv-dirs/src/lib.rs
+++ b/crates/rv-dirs/src/lib.rs
@@ -3,6 +3,17 @@ use std::{env, ffi::OsString};
 use camino::{Utf8Path, Utf8PathBuf};
 use etcetera::BaseStrategy;
 
+/// Returns an appropriate user-home directory, or the system temporary directory if the platform
+/// does not have user home directories
+pub fn home_dir() -> Utf8PathBuf {
+    etcetera::home_dir()
+        .ok()
+        .unwrap_or_else(env::temp_dir)
+        .to_string_lossy()
+        .as_ref()
+        .into()
+}
+
 /// Returns an appropriate user-level directory for storing executables.
 ///
 /// This follows, in order:
@@ -13,20 +24,13 @@ use etcetera::BaseStrategy;
 ///
 /// On all platforms.
 ///
-/// Returns `None` if a directory cannot be found, i.e., if `$HOME` cannot be resolved. Does not
-/// check if the directory exists.
-pub fn user_executable_directory(override_variable: Option<&'static str>) -> Option<Utf8PathBuf> {
+/// Does not check if the directory exists.
+pub fn user_executable_directory(override_variable: Option<&'static str>) -> Utf8PathBuf {
     override_variable
         .and_then(env::var_os)
         .and_then(parse_path)
         .or_else(|| env::var_os("XDG_BIN_HOME").and_then(parse_path))
-        .or_else(|| {
-            etcetera::home_dir()
-                .unwrap()
-                .join(".local/bin")
-                .try_into()
-                .ok()
-        })
+        .unwrap_or_else(|| home_dir().join(".local/bin"))
 }
 
 /// Returns an appropriate user-level directory for storing the cache.

--- a/crates/rv-gem-package/Cargo.toml
+++ b/crates/rv-gem-package/Cargo.toml
@@ -20,6 +20,7 @@ path = "examples/verify_gems.rs"
 
 [dev-dependencies]
 insta = { workspace = true }
+rv-dirs = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rv-gem-package/examples/verify_gems.rs
+++ b/crates/rv-gem-package/examples/verify_gems.rs
@@ -147,11 +147,7 @@ fn find_gem_files(dir: &Path) -> Result<Vec<PathBuf>> {
 
 /// Get default gem cache paths from ~/.gem/ruby/*/cache/
 fn get_default_gem_cache_paths() -> Result<Vec<PathBuf>> {
-    let home_dir = env::var("HOME")
-        .or_else(|_| env::var("USERPROFILE"))
-        .map_err(|_| miette!("Could not determine home directory"))?;
-
-    let gem_dir = Path::new(&home_dir).join(".gem").join("ruby");
+    let gem_dir = rv_dirs::home_dir().join(".gem").join("ruby");
 
     if !gem_dir.exists() {
         return Ok(vec![]);
@@ -177,7 +173,7 @@ fn get_default_gem_cache_paths() -> Result<Vec<PathBuf>> {
 
     // If no cache directories found, provide a helpful message
     if cache_paths.is_empty() {
-        eprintln!("No gem cache directories found in {}", gem_dir.display());
+        eprintln!("No gem cache directories found in {}", gem_dir);
         eprintln!("You can specify paths manually as command line arguments.");
         eprintln!(
             "Example: {} /path/to/gems /another/path",

--- a/crates/rv-ruby/Cargo.toml
+++ b/crates/rv-ruby/Cargo.toml
@@ -8,6 +8,7 @@ camino = { workspace = true, features = ["serde1"] }
 once_cell.workspace = true
 regex.workspace = true
 rv-cache = { workspace = true }
+rv-dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -7,8 +7,10 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rv_cache::{CacheKey, CacheKeyHasher};
 use serde::{Deserialize, Serialize};
-use std::env::consts::{ARCH, OS};
-use std::env::{self, home_dir};
+use std::env::{
+    self,
+    consts::{ARCH, OS},
+};
 use std::process::{Command, ExitStatus};
 use tracing::instrument;
 
@@ -117,28 +119,21 @@ impl Ruby {
         self.gem_root.clone()
     }
 
-    pub fn gem_home(&self) -> Option<Utf8PathBuf> {
-        if let Some(home) = home_dir() {
-            let legacy_path = home
-                .join(".gem")
-                .join(self.version.engine.name())
-                .join(self.version.number());
-            if legacy_path.exists() {
-                Some(legacy_path.to_str().map(Utf8PathBuf::from)?)
-            } else {
-                Some(
-                    home.join(".local")
-                        .join("share")
-                        .join("rv")
-                        .join("gems")
-                        .join(self.version.engine.name())
-                        .join(self.version.number())
-                        .to_str()
-                        .map(Utf8PathBuf::from)?,
-                )
-            }
+    pub fn gem_home(&self) -> Utf8PathBuf {
+        let home = rv_dirs::home_dir();
+        let legacy_path = home
+            .join(".gem")
+            .join(self.version.engine.name())
+            .join(self.version.number());
+        if legacy_path.exists() {
+            legacy_path
         } else {
-            None
+            home.join(".local")
+                .join("share")
+                .join("rv")
+                .join("gems")
+                .join(self.version.engine.name())
+                .join(self.version.number())
         }
     }
 

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -20,7 +20,6 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-shellexpand = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [
   "tracing",

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -1,6 +1,6 @@
 use std::{
     env::{self, JoinPathsError, join_paths, split_paths},
-    path::{Path, PathBuf},
+    path::PathBuf,
     str::FromStr,
 };
 
@@ -79,19 +79,16 @@ impl Config {
     }
 }
 
-fn xdg_data_path() -> String {
-    let xdg_data_home =
-        env::var("XDG_DATA_HOME").unwrap_or(shellexpand::tilde("~/.local/share").into());
-    let path_buf = Path::new(&xdg_data_home).join("rv/rubies");
-    path_buf.to_str().unwrap().to_owned()
+fn xdg_data_path() -> Utf8PathBuf {
+    rv_dirs::user_state_dir("/".into()).join("rubies")
 }
 
-fn legacy_default_data_path() -> String {
-    shellexpand::tilde("~/.data/rv/rubies").into()
+fn legacy_default_data_path() -> Utf8PathBuf {
+    rv_dirs::home_dir().join(".data/rv/.rubies")
 }
 
-fn legacy_default_path() -> String {
-    shellexpand::tilde("~/.rubies").into()
+fn legacy_default_path() -> Utf8PathBuf {
+    rv_dirs::home_dir().join(".rubies")
 }
 
 /// Default Ruby installation directories
@@ -237,11 +234,10 @@ pub fn env_with_path_for(
         insert("RUBY_ROOT", ruby.path.to_string());
         insert("RUBY_ENGINE", ruby.version.engine.name().into());
         insert("RUBY_VERSION", ruby.version.number());
-        if let Some(gem_home) = ruby.gem_home() {
-            paths.insert(0, gem_home.join("bin").into());
-            gem_paths.insert(0, gem_home.clone());
-            insert("GEM_HOME", gem_home.into_string());
-        }
+        let gem_home = ruby.gem_home();
+        paths.insert(0, gem_home.join("bin").into());
+        gem_paths.insert(0, gem_home.clone());
+        insert("GEM_HOME", gem_home.into_string());
         if let Some(gem_root) = ruby.gem_root() {
             paths.insert(0, gem_root.join("bin").into());
             gem_paths.insert(0, gem_root.clone());


### PR DESCRIPTION
I observed that we had a few different strategies for users without a HOME, like:

* For cache and state related directories, use a temporary directory as an alternative HOME.
* For data directories, create a relative directory named `~` (I think, because `shellexpand` will fail to expand the tilde and leave it as is).
* Ignore the situation when setting the default `GEM_HOME` in either the data directory, or in `~/.gem`, and don't set `GEM_HOME` at all.
* In some dev-only code, it would raise an error.
 
I unified everything to use an alternative temporary HOME. Honestly I've not been able to simulate the situation, this is mainly about keeping the code consistent and deleting some stuff.