### PR TITLE
Neater error when installing nonexistent Ruby version

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -6,6 +6,7 @@ use current_platform::CURRENT_PLATFORM;
 use futures_util::StreamExt;
 use indicatif::ProgressStyle;
 use owo_colors::OwoColorize;
+use reqwest::StatusCode;
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, info_span};
@@ -274,6 +275,9 @@ async fn download_ruby_archive(
     let response = request_builder.send().await?;
     if !response.status().is_success() {
         let status = response.status();
+        if status == StatusCode::NOT_FOUND {
+            return Err(Error::NoMatchingRuby);
+        }
         let body = response
             .text()
             .await


### PR DESCRIPTION
Before:
```
rv ruby install 5.0.0
× Download from URL https://github.com/spinel-coop/rv-ruby/releases/latest/download/ruby-
│ 5.0.0.arm64_sonoma.tar.gz failed with status code 404 Not Found. Response body was Not Found
```
After:
```
rv ruby install 5.0.0
× no matching ruby version found
```

Closes https://github.com/spinel-coop/rv/issues/465