### PR TITLE
Fix `--ruby-dir` flag with a relative path

### DIFF
--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -97,8 +97,8 @@ impl Cli {
         } else {
             self.ruby_dir
                 .iter()
-                .map(|path: &Utf8PathBuf| root.join(path))
-                .collect()
+                .map(|path: &Utf8PathBuf| Ok(root.join(path.canonicalize_utf8()?)))
+                .collect::<Result<Vec<_>>>()?
         };
         let ruby_dirs: IndexSet<Utf8PathBuf> = ruby_dirs.into_iter().collect();
         let cache = self.cache_args.to_cache()?;


### PR DESCRIPTION
Previously it would resolve the relative path relatively to system root, not relatively to the current directory. Seemed unexpected.

### Before

```
$ rv --ruby-dir target/tmp ruby install 4.0.1
Archive /path/to/.cache/rv/ruby-v0/tarballs/261e7356724ae45a.tar.gz already exists, skipping download.
  × failed to create directory `/target/tmp`: Read-only file system (os error 30) 
```

### After

```
$ rv --ruby-dir target/tmp ruby install 4.0.1
Archive /path/to/.cache/rv/ruby-v0/tarballs/261e7356724ae45a.tar.gz already exists, skipping download.
Installed Ruby version ruby-4.0.1 to <current-dir>/target/tmp
```