### PR TITLE
Inline matching_ruby into current_ruby

### DIFF
--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -110,16 +110,14 @@ impl Config {
         self.discover_remote_rubies().await
     }
 
-    pub fn matching_ruby(&self, request: &RubyRequest) -> Option<Ruby> {
+    pub fn current_ruby(&self) -> Option<Ruby> {
+        let request = &self.ruby_request();
+
         self.discover_rubies_matching(|dir_name| {
             RubyVersion::from_str(dir_name).is_ok_and(|v| v.satisfies(request))
         })
         .last()
         .cloned()
-    }
-
-    pub fn current_ruby(&self) -> Option<Ruby> {
-        self.matching_ruby(&self.ruby_request())
     }
 
     pub fn ruby_request(&self) -> RubyRequest {


### PR DESCRIPTION
It's only used in here, and it doesn't seem to be bad to remove the extra layer of indirection.

@deivid-rodriguez what do you think of this? does it align with what you're up to?