### PR TITLE
Add project URL and version to CLI help output

### DIFF
--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -59,14 +59,8 @@ struct GlobalArgs {
     let header_style = AnsiColor::Green.on_default().bold();
     let value_style = AnsiColor::Cyan.on_default().bold();
     format!(
-        concat!(
-            "{header_style}Project URL:{header_style:#}      {value_style}{project_url}{value_style:#}\n",
-            "{header_style}Software Version:{header_style:#} {value_style}{software_version}{value_style:#}"
-        ),
-        header_style = header_style,
-        value_style = value_style,
-        project_url = PROJECT_URL,
-        software_version = SOFTWARE_VERSION,
+        "{header_style}Project URL:{header_style:#}      {value_style}{PROJECT_URL}{value_style:#}\n\
+         {header_style}Software Version:{header_style:#} {value_style}{SOFTWARE_VERSION}{value_style:#}"
     )
 })]
 struct Cli {


### PR DESCRIPTION
I find it helpful in CLI applications when the help shows me where I can get further information. As an example, one of my CLI's outputs this in its help output:
```
-------------------------------------------------------------------------------
Usage:                 cov-loupe [options] [subcommand] [args]  (default subcommand: list)
Repository:            https://github.com/keithrbennett/cov-loupe
Documentation (Web):   https://keithrbennett.github.io/cov-loupe/
Documentation (Local): /Users/kbennett/.local/share/rv/gems/ruby/3.4.7/gems/cov-loupe-4.0.0.pre.1/lib/**/*.md
Version:               4.0.0.pre.1
-------------------------------------------------------------------------------
```

This PR adds only the Github URL at the bottom:

<img width="938" height="440" alt="image" src="https://github.com/user-attachments/assets/f6efba42-0481-4f06-8894-28040d214457" />
