### PR TITLE
Microbenchmark version comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,6 +2731,9 @@ dependencies = [
 name = "rv-version"
 version = "0.1.0"
 dependencies = [
+ "criterion",
+ "proptest",
+ "proptest-derive",
  "serde",
  "thiserror 2.0.17",
 ]

--- a/crates/rv-platform/Cargo.toml
+++ b/crates/rv-platform/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2024"
 
 [dependencies]
 current_platform = { workspace = true }
-proptest-derive = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+proptest-derive = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rv-version/Cargo.toml
+++ b/crates/rv-version/Cargo.toml
@@ -7,5 +7,14 @@ edition = "2024"
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
+[dev-dependencies]
+criterion = { workspace = true }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
+
+[[bench]]
+name = "cmp"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/rv-version/benches/cmp.rs
+++ b/crates/rv-version/benches/cmp.rs
@@ -1,0 +1,48 @@
+use std::{hint::black_box, str::FromStr};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use rv_version::Version;
+
+fn version_cmp_neither_prerelease(c: &mut Criterion) {
+    let sa = "1.82";
+    let sb = "1.82.0";
+    let va = Version::from_str(sa).unwrap();
+    let vb = Version::from_str(sb).unwrap();
+    c.bench_function(&format!("Compare {sa} and {sb}"), |b| {
+        b.iter(|| {
+            let _ver = black_box(va.cmp(&vb));
+        })
+    });
+}
+
+fn version_cmp_one_prerelease(c: &mut Criterion) {
+    let sa = "1.82";
+    let sb = "1.82.alpha1";
+    let va = Version::from_str(sa).unwrap();
+    let vb = Version::from_str(sb).unwrap();
+    c.bench_function(&format!("Compare {sa} and {sb}"), |b| {
+        b.iter(|| {
+            let _ver = black_box(va.cmp(&vb));
+        })
+    });
+}
+
+fn version_cmp_both_prerelease(c: &mut Criterion) {
+    let sa = "1.82.rc.4";
+    let sb = "1.82.alpha1";
+    let va = Version::from_str(sa).unwrap();
+    let vb = Version::from_str(sb).unwrap();
+    c.bench_function(&format!("Compare {sa} and {sb}"), |b| {
+        b.iter(|| {
+            let _ver = black_box(va.cmp(&vb));
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    version_cmp_both_prerelease,
+    version_cmp_neither_prerelease,
+    version_cmp_one_prerelease
+);
+criterion_main!(benches);

--- a/crates/rv-version/src/lib.rs
+++ b/crates/rv-version/src/lib.rs
@@ -15,6 +15,7 @@ pub enum VersionError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum VersionSegment {
     Number(u32),
     String(String),
@@ -51,6 +52,7 @@ impl std::fmt::Display for VersionSegment {
 }
 
 #[derive(Debug, Clone, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Version {
     pub version: String,
     pub segments: Vec<VersionSegment>,


### PR DESCRIPTION
Version comparison is very fast, but it could happen a LOT in a single `rvx` call as pubgrub compares many versions. So let's keep an eye on its performance. Here's the results, on my macbook M2 Pro.

Compare 1.82.rc.4 and 1.82.alpha1
283.48 ns

Compare 1.82 and 1.82.0
108.18 ns

Compare 1.82 and 1.82.alpha1
145.89 ns