### PR TITLE
Fix default gem home

### DIFF
--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -137,10 +137,7 @@ impl Ruby {
 
     pub fn gem_home(&self) -> Utf8PathBuf {
         let home = rv_dirs::home_dir();
-        let legacy_path = home
-            .join(".gem")
-            .join(self.version.engine.name())
-            .join(self.version.number());
+        let legacy_path = home.join(".gem").join(self.gem_scope());
         if legacy_path.exists() {
             legacy_path
         } else {
@@ -148,8 +145,7 @@ impl Ruby {
                 .join("share")
                 .join("rv")
                 .join("gems")
-                .join(self.version.engine.name())
-                .join(self.version.number())
+                .join(self.gem_scope())
         }
     }
 
@@ -160,6 +156,11 @@ impl Ruby {
         } else {
             None
         }
+    }
+
+    /// path scope for gems that can be safely shared with other rubies
+    pub fn gem_scope(&self) -> String {
+        format!("{}/{}", self.version.engine.name(), self.version.abi())
     }
 }
 

--- a/crates/rv-ruby/src/version.rs
+++ b/crates/rv-ruby/src/version.rs
@@ -151,6 +151,11 @@ impl RubyVersion {
         version
     }
 
+    /// ABI compatibility version for this ruby version.
+    pub fn abi(&self) -> String {
+        format!("{}.{}.0", self.major, self.minor)
+    }
+
     /// Is this ruby version a prerelease.
     pub fn is_prerelease(&self) -> bool {
         self.prerelease.is_some()

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -120,7 +120,10 @@ impl RvTest {
     }
 
     pub fn legacy_gem_path(&self, version: &str) -> Utf8PathBuf {
-        self.temp_home().join(".gem").join("ruby").join(version)
+        self.temp_home()
+            .join(".gem")
+            .join("ruby")
+            .join(format!("{version}.0"))
     }
 
     pub fn rv(&self, args: &[&str]) -> RvOutput {

--- a/crates/rv/tests/integration_tests/shell/env_test.rs
+++ b/crates/rv/tests/integration_tests/shell/env_test.rs
@@ -98,7 +98,7 @@ fn test_shell_env_with_ruby_and_xdg_compatible_gem_path() {
     test.create_ruby_dir("ruby-3.3.5");
 
     // Ensure the legacy path is not present.
-    rm_rf(test.legacy_gem_path("3.3.5")).unwrap();
+    rm_rf(test.legacy_gem_path("3.3")).unwrap();
 
     test.env.insert("PATH".into(), "/tmp/bin".into());
     test.env.insert("RUBY_ROOT".into(), "/tmp/ruby".into());
@@ -123,10 +123,10 @@ fn test_shell_env_with_ruby_and_xdg_compatible_gem_path() {
     export RUBY_ROOT=/tmp/home/.local/share/rv/rubies/ruby-3.3.5
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME=/tmp/home/.local/share/rv/gems/ruby/3.3.5
-    export GEM_PATH=/tmp/home/.local/share/rv/gems/ruby/3.3.5
+    export GEM_HOME=/tmp/home/.local/share/rv/gems/ruby/3.3.0
+    export GEM_PATH=/tmp/home/.local/share/rv/gems/ruby/3.3.0
     export MANPATH='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:'
-    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.5/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 
@@ -140,9 +140,9 @@ fn test_shell_env_with_ruby_and_xdg_compatible_gem_path() {
     export RUBY_ROOT='/tmp/home/.local/share/rv/rubies/ruby-3.3.5'
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME='/tmp/home/.local/share/rv/gems/ruby/3.3.5'
-    export GEM_PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.5'
-    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.5/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export GEM_HOME='/tmp/home/.local/share/rv/gems/ruby/3.3.0'
+    export GEM_PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0'
+    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 }
@@ -153,7 +153,7 @@ fn test_shell_env_with_ruby_and_legacy_gem_path() {
     test.create_ruby_dir("ruby-3.3.5");
 
     // Ensure the legacy path is present.
-    create_dir_all(test.legacy_gem_path("3.3.5")).unwrap();
+    create_dir_all(test.legacy_gem_path("3.3")).unwrap();
 
     test.env.insert("PATH".into(), "/tmp/bin".into());
     test.env.insert("RUBY_ROOT".into(), "/tmp/ruby".into());
@@ -178,10 +178,10 @@ fn test_shell_env_with_ruby_and_legacy_gem_path() {
     export RUBY_ROOT=/tmp/home/.local/share/rv/rubies/ruby-3.3.5
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME=/tmp/home/.gem/ruby/3.3.5
-    export GEM_PATH=/tmp/home/.gem/ruby/3.3.5
+    export GEM_HOME=/tmp/home/.gem/ruby/3.3.0
+    export GEM_PATH=/tmp/home/.gem/ruby/3.3.0
     export MANPATH='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:'
-    export PATH='/tmp/home/.gem/ruby/3.3.5/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 
@@ -191,9 +191,9 @@ fn test_shell_env_with_ruby_and_legacy_gem_path() {
     export RUBY_ROOT='/tmp/home/.local/share/rv/rubies/ruby-3.3.5'
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME='/tmp/home/.gem/ruby/3.3.5'
-    export GEM_PATH='/tmp/home/.gem/ruby/3.3.5'
-    export PATH='/tmp/home/.gem/ruby/3.3.5/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export GEM_HOME='/tmp/home/.gem/ruby/3.3.0'
+    export GEM_PATH='/tmp/home/.gem/ruby/3.3.0'
+    export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 }
@@ -204,7 +204,7 @@ fn test_powershell_env_with_ruby() {
     test.create_ruby_dir("ruby-3.3.5");
 
     // Ensure the legacy path is present.
-    create_dir_all(test.legacy_gem_path("3.3.5")).unwrap();
+    create_dir_all(test.legacy_gem_path("3.3")).unwrap();
 
     test.env.insert("PATH".into(), "/tmp/bin".into());
 
@@ -220,10 +220,10 @@ fn test_powershell_env_with_ruby() {
     $env:RUBY_ROOT = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5"
     $env:RUBY_ENGINE = "ruby"
     $env:RUBY_VERSION = "3.3.5"
-    $env:GEM_HOME = "/tmp/home/.gem/ruby/3.3.5"
-    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.5"
+    $env:GEM_HOME = "/tmp/home/.gem/ruby/3.3.0"
+    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.0"
     $env:MANPATH = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:"
-    $env:PATH = "/tmp/home/.gem/ruby/3.3.5/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin"
+    $env:PATH = "/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin"
     "#);
 
     #[cfg(windows)]
@@ -234,9 +234,9 @@ fn test_powershell_env_with_ruby() {
     $env:RUBY_ROOT = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5"
     $env:RUBY_ENGINE = "ruby"
     $env:RUBY_VERSION = "3.3.5"
-    $env:GEM_HOME = "/tmp/home/.gem/ruby/3.3.5"
-    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.5"
-    $env:PATH = "/tmp/home/.gem/ruby/3.3.5/bin;/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin;/tmp/bin"
+    $env:GEM_HOME = "/tmp/home/.gem/ruby/3.3.0"
+    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.0"
+    $env:PATH = "/tmp/home/.gem/ruby/3.3.0/bin;/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin;/tmp/bin"
     "#);
 }
 
@@ -253,7 +253,7 @@ fn test_shell_env_with_existing_manpath() {
     );
 
     // Ensure the legacy path is present.
-    create_dir_all(test.legacy_gem_path("3.3.5")).unwrap();
+    create_dir_all(test.legacy_gem_path("3.3")).unwrap();
 
     test.env.insert("PATH".into(), "/tmp/bin".into());
 

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_existing_manpath.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_existing_manpath.snap
@@ -6,8 +6,8 @@ unset RUBYOPT GEM_ROOT
 export RUBY_ROOT=/tmp/home/.local/share/rv/rubies/ruby-3.3.5
 export RUBY_ENGINE=ruby
 export RUBY_VERSION=3.3.5
-export GEM_HOME=/tmp/home/.gem/ruby/3.3.5
-export GEM_PATH=/tmp/home/.gem/ruby/3.3.5
+export GEM_HOME=/tmp/home/.gem/ruby/3.3.0
+export GEM_PATH=/tmp/home/.gem/ruby/3.3.0
 export MANPATH='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:/usr/share/man:/usr/local/share/man'
-export PATH='/tmp/home/.gem/ruby/3.3.5/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
 hash -r


### PR DESCRIPTION
RubyGems sets the default gem path in user home to a directory that can be reused across abi-compatible rubies. We should do the same.