### PR TITLE
Log `rv ci` install path

### DIFF
--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -270,7 +270,8 @@ async fn ci_inner_work(
     progress: &WorkProgress,
     mut lockfile: GemfileDotLock<'_>,
 ) -> Result<InstallStats> {
-    let binstub_dir = args.install_path.join("bin");
+    let install_path = &args.install_path;
+    let binstub_dir = install_path.join("bin");
     tokio::fs::create_dir_all(&binstub_dir).await?;
 
     // Filter to gems matching local platform, preferring platform-specific gems
@@ -281,7 +282,7 @@ async fn ci_inner_work(
 
     if !args.force {
         let original_count = lockfile.spec_count();
-        lockfile.discard_installed_gems(&args.install_path);
+        lockfile.discard_installed_gems(install_path);
         let filtered_count = lockfile.spec_count();
 
         let already_installed = original_count.saturating_sub(filtered_count);
@@ -294,7 +295,7 @@ async fn ci_inner_work(
             };
 
             println!(
-                "{n_gems} already installed, skipping installation. Use --force if you want to install these gems again.",
+                "{n_gems} already installed in {install_path}, skipping installation. Use --force if you want to install these gems again.",
             );
         }
 
@@ -346,7 +347,7 @@ async fn ci_inner_work(
 
     let (cached_count, network_count) = stats.counts();
 
-    println!("{} gems installed:", total_gems);
+    println!("{} gems installed to {}:", total_gems, install_path);
     println!(
         " - {} fetching {} gems from gem servers ({} cached, {} downloaded), {} from git repos, {} from local paths",
         format_duration(fetch_elapsed),

--- a/crates/rv/tests/integration_tests/clean_install.rs
+++ b/crates/rv/tests/integration_tests/clean_install.rs
@@ -199,7 +199,9 @@ fn test_clean_install_native_and_generic_reinstall() {
     let output = test.ci(&[]);
 
     output.assert_success();
-    output.assert_stdout_contains("1 gem already installed, skipping installation");
+    output.assert_stdout_contains(
+        "1 gem already installed in /tmp/app/ruby/4.0.0, skipping installation",
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
To be honest, I'm not sure if this is worth it or just makes the output dense for little benefit.

I did find it useful when troubleshooting some `rv ci` issues but I'm unsure if useful for users in general.

If not, I can always log it only in debug mode. Let me know!  