### PR TITLE
Make test fail with a clear message when a shell is not installed.

### DIFF
--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -563,6 +563,10 @@ impl RvTest {
     }
 }
 
+pub fn is_shell_installed(shell_name: &str) -> bool {
+    Command::new(shell_name).arg("--version").output().is_ok()
+}
+
 #[derive(Debug)]
 pub struct RvOutput {
     pub output: std::process::Output,

--- a/crates/rv/tests/integration_tests/shell/init_test.rs
+++ b/crates/rv/tests/integration_tests/shell/init_test.rs
@@ -40,6 +40,11 @@ fn test_switch_rubies_bash() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_switch_rubies_fish() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(
+        crate::common::is_shell_installed("fish"),
+        "Test requires 'fish' shell to be installed"
+    );
+
     let shell = Shell {
         name: "fish",
         startup_flag: "--no-config",
@@ -52,6 +57,11 @@ fn test_switch_rubies_fish() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(unix)]
 #[test]
 fn test_switch_rubies_zsh() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(
+        crate::common::is_shell_installed("zsh"),
+        "Test requires 'zsh' shell to be installed"
+    );
+
     let shell = Shell {
         name: "zsh",
         startup_flag: "--no-rcs",


### PR DESCRIPTION
I have not `zsh` installed in my system, I use just `fish`. So this test was always failing, I thought to add a runtime skip, but that is not possible in Rust (Based on what I reed), maybe there is a chance with `next-test`.

So I just make fail it with a clear message. 

Before:
```bash
        PASS [   0.010s] rv-gem-specification-yaml to_ruby::tests::test_prism
        FAIL [   0.318s] rv::integration_tests shell::init_test::test_switch_rubies_zsh
  stdout ───

    running 1 test
    test shell::init_test::test_switch_rubies_zsh ... FAILED

    failures:

    failures:
        shell::init_test::test_switch_rubies_zsh

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 97 filtered out; finished in 0.31s
    
  stderr ───
    Error: EOF { expected: "\"PEXPECT>\"", got: "fatal runtime error: IO Safety violation: owned file descriptor already closed, aborting\r\n", exit_code: None }

        PASS [   0.008s] rv-gem-specification-yaml to_ruby::tests::test_psych

```

After:

```bash
        PASS [   0.440s] rv::integration_tests clean_install::test_clean_install_native_linux_x86_64
        FAIL [   0.008s] rv::integration_tests shell::init_test::test_switch_rubies_zsh
  stdout ───

    running 1 test
    test shell::init_test::test_switch_rubies_zsh ... FAILED

    failures:

    failures:
        shell::init_test::test_switch_rubies_zsh

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 97 filtered out; finished in 0.00s
    
  stderr ───

    thread 'shell::init_test::test_switch_rubies_zsh' (259308) panicked at crates/rv/tests/integration_tests/shell/init_test.rs:60:5:
    Test requires 'zsh' shell to be installed
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

        PASS [   0.022s] rv::integration_tests shell::init_test::test_shell_init_fails_without_shell

```

With zsh installed:
```bash
        PASS [   0.622s] rv::integration_tests shell::init_test::test_switch_rubies_zsh
```