### PR TITLE
Refactor duplicated method in Request and Version - to_tool_consumable_version

### DIFF
--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod engine;
 pub mod request;
+pub mod tool_consumable;
 pub mod version;
 
 use camino::{Utf8Path, Utf8PathBuf};

--- a/crates/rv-ruby/src/request.rs
+++ b/crates/rv-ruby/src/request.rs
@@ -71,11 +71,6 @@ impl RubyRequest {
             .find(|r| r.version.satisfies(self))
             .cloned()
     }
-
-    /// A version that toolfiles like .tool-version/.ruby-version/Gemfile/Gemfile.lock knows how to read.
-    pub fn to_tool_consumable_version(&self) -> String {
-        self.to_string().replace("ruby-", "")
-    }
 }
 
 impl FromStr for RubyRequest {

--- a/crates/rv-ruby/src/tool_consumable.rs
+++ b/crates/rv-ruby/src/tool_consumable.rs
@@ -1,0 +1,11 @@
+use crate::{request::RubyRequest, version::RubyVersion};
+use std::fmt::Display;
+
+pub trait ToolConsumable: Display {
+    fn to_tool_consumable_string(&self) -> String {
+        self.to_string().replace("ruby-", "")
+    }
+}
+
+impl ToolConsumable for RubyRequest {}
+impl ToolConsumable for RubyVersion {}

--- a/crates/rv-ruby/src/version.rs
+++ b/crates/rv-ruby/src/version.rs
@@ -186,10 +186,6 @@ impl RubyVersion {
 
         version.parse()
     }
-
-    pub fn to_tool_consumable_version(&self) -> String {
-        self.to_string().replace("ruby-", "")
-    }
 }
 
 impl std::fmt::Display for RubyVersion {

--- a/crates/rv/src/commands/ruby/pin.rs
+++ b/crates/rv/src/commands/ruby/pin.rs
@@ -6,6 +6,7 @@ use anstream::println;
 use miette::Diagnostic;
 use once_cell::sync::Lazy;
 use owo_colors::OwoColorize;
+use rv_ruby::tool_consumable::ToolConsumable;
 use tracing::debug;
 
 use rv_ruby::request::RubyRequest;
@@ -58,9 +59,9 @@ pub(crate) async fn pin(
             .find_matching_remote_ruby()
             .await?;
 
-        resolved.to_tool_consumable_version()
+        resolved.to_tool_consumable_string()
     } else {
-        ruby_request.to_tool_consumable_version()
+        ruby_request.to_tool_consumable_string()
     };
 
     set_pinned_ruby(config, version)
@@ -121,9 +122,9 @@ async fn show_pinned_ruby(config: &Config, resolved: bool) -> Result<()> {
 
     let version = if resolved {
         let resolved_ruby = config.find_matching_remote_ruby().await?;
-        resolved_ruby.to_tool_consumable_version()
+        resolved_ruby.to_tool_consumable_string()
     } else {
-        ruby.to_tool_consumable_version()
+        ruby.to_tool_consumable_string()
     };
 
     println!("{0} is pinned to {1}", dir.as_ref().cyan(), version.cyan());


### PR DESCRIPTION
I duplicate a method in my last work with the support of `latest` word as argument for install and pin. Here is a solution.

@deivid-rodriguez like you said, I can solve it implementing a trait. What do you think about it?

All is working as expected, just that now we have only one point to update the consumable string if we need to do it.