### PR TITLE
Add force flag to install command

### DIFF
--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -183,7 +183,7 @@ pub(crate) async fn ci(global_args: &GlobalArgs, args: CleanInstallArgs) -> Resu
     // We need some Ruby installed, because we need to run Ruby code when installing
     // gems. Ensure Ruby is installed here so we can use it later.
     if config.current_ruby().is_none() {
-        ruby_install(global_args, None, None, None).await?;
+        ruby_install(global_args, None, None, None, false).await?;
     }
 
     // Now that it's installed, we can use Ruby to query various directories
@@ -241,7 +241,7 @@ pub(crate) async fn install_from_lockfile(
     // We need some Ruby installed, because we need to run Ruby code when installing
     // gems. Ensure Ruby is installed here so we can use it later.
     if config.current_ruby().is_none() {
-        ruby_install(global_args, None, request, None).await?;
+        ruby_install(global_args, None, request, None, false).await?;
     }
 
     let ruby = config

--- a/crates/rv/src/commands/ruby.rs
+++ b/crates/rv/src/commands/ruby.rs
@@ -70,6 +70,10 @@ pub enum RubyCommand {
         /// Path to a local ruby tarball
         #[arg(long, value_name = "TARBALL_PATH")]
         tarball_path: Option<Utf8PathBuf>,
+
+        /// Overwrite an existing installed version.
+        #[arg(long)]
+        force: bool,
     },
 
     #[command(about = "Uninstall a specific Ruby version")]
@@ -132,7 +136,8 @@ pub(crate) async fn ruby(global_args: &GlobalArgs, args: RubyArgs) -> Result<()>
             version,
             install_dir,
             tarball_path,
-        } => install::install(global_args, install_dir, version, tarball_path).await?,
+            force,
+        } => install::install(global_args, install_dir, version, tarball_path, force).await?,
         RubyCommand::Uninstall { version } => uninstall::uninstall(global_args, version).await?,
         RubyCommand::Run {
             version,

--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -55,6 +55,7 @@ pub(crate) async fn install(
     install_dir: Option<String>,
     request: Option<RubyRequest>,
     tarball_path: Option<Utf8PathBuf>,
+    force: bool,
 ) -> Result<()> {
     let config = &Config::new(global_args, request)?;
 
@@ -84,6 +85,12 @@ pub(crate) async fn install(
             None => panic!("No Ruby directories to install into"),
         },
     };
+
+    if config.is_requested_ruby_installed_in_dir(&install_dir) && !force {
+        println!("Version already installed. If you want to overwrite it, use '--force'.");
+
+        return Ok(());
+    }
 
     let archive_path = if let Some(path) = tarball_path {
         path

--- a/crates/rv/src/commands/ruby/run.rs
+++ b/crates/rv/src/commands/ruby/run.rs
@@ -99,6 +99,7 @@ pub(crate) async fn run<A: AsRef<std::ffi::OsStr>>(
             install_dir,
             Some(request),
             tarball_path,
+            false,
         )
         .await?
     };

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -167,6 +167,18 @@ impl Config {
             RequestedRuby::Global => RubyRequest::default(),
         }
     }
+
+    pub fn is_requested_ruby_installed_in_dir(&self, install_root: &Utf8Path) -> bool {
+        let requested_ruby_name = self.ruby_request().to_string();
+
+        let install_path = install_root.join(requested_ruby_name);
+
+        let managed = self.ruby_dirs.first().is_some_and(|d| *d == *install_root);
+
+        Ruby::from_dir(install_path, managed)
+            .map(|ruby| ruby.is_valid())
+            .unwrap_or(false)
+    }
 }
 
 fn xdg_data_path() -> Utf8PathBuf {

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -206,10 +206,31 @@ fn test_ruby_install_cached_file_reused() {
     output1.assert_success();
 
     // This one should just reuse the cached tarball without downloading.
-    let output2 = test.rv(&["ruby", "install", "3.4.5"]);
+    let output2 = test.rv(&["ruby", "install", "3.4.5", "--force"]);
     output2.assert_success();
 
     output2.assert_stdout_contains("already exists, skipping download");
+
+    mock.assert();
+}
+
+#[test]
+fn test_ruby_install_skips_existing_version_and_suggests_force_flag() {
+    let mut test = RvTest::new();
+
+    let mock = test.mock_ruby_download("3.4.5").create();
+
+    let _cache_dir = test.enable_cache();
+
+    // First installation – should succeed
+    let output1 = test.rv(&["ruby", "install", "3.4.5"]);
+    output1.assert_success();
+
+    // Second installation – should report that it’s already present
+    let output2 = test.rv(&["ruby", "install", "3.4.5"]);
+    output2.assert_success();
+
+    output2.assert_stdout_contains("If you want to overwrite it, use '--force'.");
 
     mock.assert();
 }


### PR DESCRIPTION
Finally, I chose `--force` flag for install command. This closes #533.

I was thinking that make the difference with --force and --reinstall is not necessary for rv. Anyway, I wait comments on it.

