### PR TITLE
RubyGems default GEM_HOME is ruby version dependent

### DIFF
--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -127,11 +127,21 @@ impl Ruby {
         self.path.join("bin")
     }
 
+    pub fn gem_home(&self) -> Utf8PathBuf {
+        self.gem_root().unwrap_or(
+            self.path
+                .join("lib")
+                .join("ruby")
+                .join("gems")
+                .join(self.version.abi()),
+        )
+    }
+
     pub fn gem_root(&self) -> Option<Utf8PathBuf> {
         self.gem_root.clone()
     }
 
-    pub fn gem_home(&self) -> Utf8PathBuf {
+    pub fn user_home(&self) -> Utf8PathBuf {
         let home = rv_dirs::home_dir();
         let legacy_path = home.join(".gem").join(self.gem_scope());
         if legacy_path.exists() {

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -246,12 +246,11 @@ fn find_directory_ruby(dir: &Utf8PathBuf) -> Result<Option<(RubyRequest, Source)
     Ok(None)
 }
 
-const ENV_VARS: [&str; 8] = [
+const ENV_VARS: [&str; 7] = [
     "RUBY_ROOT",
     "RUBY_ENGINE",
     "RUBY_VERSION",
     "RUBYOPT",
-    "GEM_ROOT",
     "GEM_HOME",
     "GEM_PATH",
     "MANPATH",
@@ -283,7 +282,7 @@ pub fn env_with_path_for(
     let mut paths = split_paths(&pathstr).collect::<Vec<_>>();
     paths.extend(extra_paths);
 
-    let old_ruby_paths: Vec<PathBuf> = ["RUBY_ROOT", "GEM_ROOT", "GEM_HOME"]
+    let old_ruby_paths: Vec<PathBuf> = ["RUBY_ROOT", "GEM_HOME"]
         .iter()
         .filter_map(|var| env::var(var).ok())
         .map(|p| std::path::Path::new(&p).join("bin"))
@@ -305,11 +304,9 @@ pub fn env_with_path_for(
         paths.insert(0, gem_home.join("bin").into());
         gem_paths.insert(0, gem_home.clone());
         insert("GEM_HOME", gem_home.into_string());
-        if let Some(gem_root) = ruby.gem_root() {
-            paths.insert(0, gem_root.join("bin").into());
-            gem_paths.insert(0, gem_root.clone());
-            insert("GEM_ROOT", gem_root.into_string());
-        }
+        let user_home = ruby.user_home();
+        paths.insert(0, user_home.join("bin").into());
+        gem_paths.insert(0, user_home);
         let gem_path = join_paths(gem_paths)?;
         if let Some(gem_path) = gem_path.to_str() {
             insert("GEM_PATH", gem_path.into());

--- a/crates/rv/tests/integration_tests/shell/env_test.rs
+++ b/crates/rv/tests/integration_tests/shell/env_test.rs
@@ -77,7 +77,6 @@ fn test_shell_env_clears_ruby_vars() {
 fn test_shell_env_clear_gem_vars() {
     let mut test = RvTest::new();
     test.env.insert("PATH".into(), "/tmp/bin".into());
-    test.env.insert("GEM_ROOT".into(), "/tmp/ruby/gems".into());
     test.env.insert("GEM_HOME".into(), "/tmp/root/.gems".into());
     test.env.insert(
         "GEM_PATH".into(),
@@ -105,7 +104,6 @@ fn test_shell_env_with_ruby_and_xdg_compatible_gem_path() {
     test.env.insert("RUBY_ENGINE".into(), "ruby".into());
     test.env.insert("RUBY_VERSION".into(), "3.4.5".into());
     test.env.insert("RUBYOPT".into(), "--verbose".into());
-    test.env.insert("GEM_ROOT".into(), "/tmp/ruby/gems".into());
     test.env.insert("GEM_HOME".into(), "/tmp/root/.gems".into());
     test.env.insert(
         "GEM_PATH".into(),
@@ -119,14 +117,14 @@ fn test_shell_env_with_ruby_and_xdg_compatible_gem_path() {
 
     #[cfg(unix)]
     assert_snapshot!(stdout, @r"
-    unset RUBYOPT GEM_ROOT
+    unset RUBYOPT
     export RUBY_ROOT=/tmp/home/.local/share/rv/rubies/ruby-3.3.5
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME=/tmp/home/.local/share/rv/gems/ruby/3.3.0
-    export GEM_PATH=/tmp/home/.local/share/rv/gems/ruby/3.3.0
+    export GEM_HOME=/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0
+    export GEM_PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0'
     export MANPATH='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:'
-    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 
@@ -136,13 +134,13 @@ fn test_shell_env_with_ruby_and_xdg_compatible_gem_path() {
     // but the quotes remain. This is semantically correct for bash.
     #[cfg(windows)]
     assert_snapshot!(stdout, @r"
-    unset RUBYOPT GEM_ROOT MANPATH
+    unset RUBYOPT MANPATH
     export RUBY_ROOT='/tmp/home/.local/share/rv/rubies/ruby-3.3.5'
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME='/tmp/home/.local/share/rv/gems/ruby/3.3.0'
-    export GEM_PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0'
-    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export GEM_HOME='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0'
+    export GEM_PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0'
+    export PATH='/tmp/home/.local/share/rv/gems/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 }
@@ -160,7 +158,6 @@ fn test_shell_env_with_ruby_and_legacy_gem_path() {
     test.env.insert("RUBY_ENGINE".into(), "ruby".into());
     test.env.insert("RUBY_VERSION".into(), "3.4.5".into());
     test.env.insert("RUBYOPT".into(), "--verbose".into());
-    test.env.insert("GEM_ROOT".into(), "/tmp/ruby/gems".into());
     test.env.insert("GEM_HOME".into(), "/tmp/root/.gems".into());
     test.env.insert(
         "GEM_PATH".into(),
@@ -174,26 +171,26 @@ fn test_shell_env_with_ruby_and_legacy_gem_path() {
 
     #[cfg(unix)]
     assert_snapshot!(stdout, @r"
-    unset RUBYOPT GEM_ROOT
+    unset RUBYOPT
     export RUBY_ROOT=/tmp/home/.local/share/rv/rubies/ruby-3.3.5
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME=/tmp/home/.gem/ruby/3.3.0
-    export GEM_PATH=/tmp/home/.gem/ruby/3.3.0
+    export GEM_HOME=/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0
+    export GEM_PATH='/tmp/home/.gem/ruby/3.3.0:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0'
     export MANPATH='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:'
-    export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 
     #[cfg(windows)]
     assert_snapshot!(stdout, @r"
-    unset RUBYOPT GEM_ROOT MANPATH
+    unset RUBYOPT MANPATH
     export RUBY_ROOT='/tmp/home/.local/share/rv/rubies/ruby-3.3.5'
     export RUBY_ENGINE=ruby
     export RUBY_VERSION=3.3.5
-    export GEM_HOME='/tmp/home/.gem/ruby/3.3.0'
-    export GEM_PATH='/tmp/home/.gem/ruby/3.3.0'
-    export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+    export GEM_HOME='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0'
+    export GEM_PATH='/tmp/home/.gem/ruby/3.3.0:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0'
+    export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
     hash -r
     ");
 }
@@ -216,27 +213,25 @@ fn test_powershell_env_with_ruby() {
     #[cfg(unix)]
     assert_snapshot!(stdout, @r#"
     Remove-Item Env:\RUBYOPT -ErrorAction SilentlyContinue
-    Remove-Item Env:\GEM_ROOT -ErrorAction SilentlyContinue
     $env:RUBY_ROOT = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5"
     $env:RUBY_ENGINE = "ruby"
     $env:RUBY_VERSION = "3.3.5"
-    $env:GEM_HOME = "/tmp/home/.gem/ruby/3.3.0"
-    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.0"
+    $env:GEM_HOME = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0"
+    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.0:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0"
     $env:MANPATH = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:"
-    $env:PATH = "/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin"
+    $env:PATH = "/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin"
     "#);
 
     #[cfg(windows)]
     assert_snapshot!(stdout, @r#"
     Remove-Item Env:\RUBYOPT -ErrorAction SilentlyContinue
-    Remove-Item Env:\GEM_ROOT -ErrorAction SilentlyContinue
     Remove-Item Env:\MANPATH -ErrorAction SilentlyContinue
     $env:RUBY_ROOT = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5"
     $env:RUBY_ENGINE = "ruby"
     $env:RUBY_VERSION = "3.3.5"
-    $env:GEM_HOME = "/tmp/home/.gem/ruby/3.3.0"
-    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.0"
-    $env:PATH = "/tmp/home/.gem/ruby/3.3.0/bin;/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin;/tmp/bin"
+    $env:GEM_HOME = "/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0"
+    $env:GEM_PATH = "/tmp/home/.gem/ruby/3.3.0;/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0"
+    $env:PATH = "/tmp/home/.gem/ruby/3.3.0/bin;/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0/bin;/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin;/tmp/bin"
     "#);
 }
 

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__bash_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__bash_succeeds.snap
@@ -2,6 +2,6 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT GEM_HOME GEM_PATH MANPATH
+unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_HOME GEM_PATH MANPATH
 export PATH=''
 hash -r

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__fish_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__fish_succeeds.snap
@@ -2,5 +2,5 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-set -ge RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT GEM_HOME GEM_PATH MANPATH
+set -ge RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_HOME GEM_PATH MANPATH
 set -gx PATH ""

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__nu_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__nu_succeeds.snap
@@ -2,4 +2,4 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-{"GEM_HOME":{},"GEM_PATH":{},"GEM_ROOT":{},"MANPATH":{},"PATH":"","RUBYOPT":{},"RUBY_ENGINE":{},"RUBY_ROOT":{},"RUBY_VERSION":{}}
+{"GEM_HOME":{},"GEM_PATH":{},"MANPATH":{},"PATH":"","RUBYOPT":{},"RUBY_ENGINE":{},"RUBY_ROOT":{},"RUBY_VERSION":{}}

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__powershell_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__powershell_succeeds.snap
@@ -6,7 +6,6 @@ Remove-Item Env:\RUBY_ROOT -ErrorAction SilentlyContinue
 Remove-Item Env:\RUBY_ENGINE -ErrorAction SilentlyContinue
 Remove-Item Env:\RUBY_VERSION -ErrorAction SilentlyContinue
 Remove-Item Env:\RUBYOPT -ErrorAction SilentlyContinue
-Remove-Item Env:\GEM_ROOT -ErrorAction SilentlyContinue
 Remove-Item Env:\GEM_HOME -ErrorAction SilentlyContinue
 Remove-Item Env:\GEM_PATH -ErrorAction SilentlyContinue
 Remove-Item Env:\MANPATH -ErrorAction SilentlyContinue

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_clear_gem_vars.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_clear_gem_vars.snap
@@ -2,6 +2,6 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT GEM_HOME GEM_PATH MANPATH
+unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_HOME GEM_PATH MANPATH
 export PATH=/tmp/bin
 hash -r

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_clears_ruby_vars.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_clears_ruby_vars.snap
@@ -2,6 +2,6 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT GEM_HOME GEM_PATH MANPATH
+unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_HOME GEM_PATH MANPATH
 export PATH=/tmp/bin
 hash -r

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_existing_manpath.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_existing_manpath.snap
@@ -2,12 +2,12 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-unset RUBYOPT GEM_ROOT
+unset RUBYOPT
 export RUBY_ROOT=/tmp/home/.local/share/rv/rubies/ruby-3.3.5
 export RUBY_ENGINE=ruby
 export RUBY_VERSION=3.3.5
-export GEM_HOME=/tmp/home/.gem/ruby/3.3.0
-export GEM_PATH=/tmp/home/.gem/ruby/3.3.0
+export GEM_HOME=/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0
+export GEM_PATH='/tmp/home/.gem/ruby/3.3.0:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0'
 export MANPATH='/tmp/home/.local/share/rv/rubies/ruby-3.3.5/share/man:/usr/share/man:/usr/local/share/man'
-export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
+export PATH='/tmp/home/.gem/ruby/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/lib/ruby/gems/3.3.0/bin:/tmp/home/.local/share/rv/rubies/ruby-3.3.5/bin:/tmp/bin'
 hash -r

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_path.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__shell_env_with_path.snap
@@ -2,6 +2,6 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT GEM_HOME GEM_PATH MANPATH
+unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_HOME GEM_PATH MANPATH
 export PATH=/tmp/bin
 hash -r

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__zsh_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__env_test__zsh_succeeds.snap
@@ -2,6 +2,6 @@
 source: crates/rv/tests/integration_tests/shell/env_test.rs
 expression: output.normalized_stdout()
 ---
-unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT GEM_HOME GEM_PATH MANPATH
+unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_HOME GEM_PATH MANPATH
 export PATH=''
 hash -r


### PR DESCRIPTION
But we were setting it to what RubyGems calls "user gem home". We should probably use the same RubyGems uses for compatibility.

Also, I've never heard of GEM_ROOT. Does it make sense to set this ENV variable?