### PR TITLE
Add a `--quiet` parameter to bin/rv

### DIFF
--- a/bin/rv
+++ b/bin/rv
@@ -2,11 +2,24 @@
 set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}"/ )/.." && pwd )"
 
-echo "+ cargo build --release -q --bin rv"
+if [ "$1" != "--quiet" ]
+then
+  echo "+ cargo build --release -q --bin rv"
+fi
+
 (
     cd "$DIR"
     cargo build --release -q --bin rv
 )
 
-set -x
+if [ "$1" != "--quiet" ]
+then
+  set -x
+fi
+
+if [ "$1" = "--quiet" ]
+then
+  shift 1
+fi
+
 exec "$DIR"/target/release/rv "$@"


### PR DESCRIPTION
So that we can use `bin/rv` to activate shell integration with.

For example, for zsh, you can now do that with:

```
eval "$(/path/to/bin/rv --quiet shell init zsh)"
```