### PR TITLE
Last changes break bin/rv if `--quiet` is not setted.

### DIFF
--- a/bin/rv
+++ b/bin/rv
@@ -2,7 +2,7 @@
 set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}"/ )/.." && pwd )"
 
-if [ "$1" != "--quiet" ]
+if [ "${1:-}" != "--quiet" ]
 then
   echo "+ cargo build --release -q --bin rv"
 fi
@@ -12,14 +12,9 @@ fi
     cargo build --release -q --bin rv
 )
 
-if [ "$1" != "--quiet" ]
+if [ "${1:-}" != "--quiet" ]
 then
   set -x
-fi
-
-if [ "$1" = "--quiet" ]
-then
-  shift 1
 fi
 
 exec "$DIR"/target/release/rv "$@"


### PR DESCRIPTION
I just updated my branch and I notice this:

<img width="754" height="136" alt="imagen" src="https://github.com/user-attachments/assets/2b46799b-d3f9-4942-ba4d-35c92f6cb977" />

Was failing because I don't use the ´--quiet´ parameter.

**I am not a bash expert, the code was suggested by LLM and just worked for me**