### PR TITLE
Fix regression finding extensions dir

### DIFF
--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -1496,7 +1496,9 @@ fn find_exts_scope(config: &Config) -> Result<String> {
     )?
     .stdout;
 
-    let extensions_scope = String::from_utf8(exts_scope).map_err(|_| Error::BadExtensionsScope)?;
+    let extensions_scope = String::from_utf8(exts_scope)
+        .map(|s| s.trim().to_string())
+        .map_err(|_| Error::BadExtensionsScope)?;
     debug!("Found extensions scope: {extensions_scope}");
     Ok(extensions_scope)
 }


### PR DESCRIPTION
I introduced this in 4ba61891d2b868b21601d85c4c1ad833f547860b where I unintentionally removed the `.trim()`.