### PR TITLE
More 🥓 tweaks

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -18,9 +18,12 @@ need_stdout = false
 command = ["cargo", "check", "--all-targets"]
 need_stdout = false
 
-# Run clippy on the default target
-[jobs.clippy]
-command = ["cargo", "clippy"]
+[jobs.lint]
+command = ["bin/lint"]
+need_stdout = false
+
+[jobs.fix]
+command = ["bin/lint", "--fix"]
 need_stdout = false
 
 [jobs.reinstall]
@@ -30,23 +33,6 @@ need_stdout = false
 
 [jobs.install]
 command = ["cargo", "install", "--path", "crates/rv", "--locked", "--quiet"]
-need_stdout = false
-
-
-# Run clippy on all targets
-# To disable some lints, you may change the job this way:
-#    [jobs.clippy-all]
-#    command = [
-#        "cargo", "clippy",
-#        "--all-targets",
-#    	 "--",
-#    	 "-A", "clippy::bool_to_int_with_if",
-#    	 "-A", "clippy::collapsible_if",
-#    	 "-A", "clippy::derive_partial_eq_without_eq",
-#    ]
-# need_stdout = false
-[jobs.clippy-all]
-command = ["cargo", "clippy", "--all-targets"]
 need_stdout = false
 
 # This job lets you run
@@ -120,4 +106,5 @@ allow_warnings = true
 # should go in your personal global prefs.toml file instead.
 [keybindings]
 # alt-m = "job:my-job"
-c = "job:clippy-all" # comment this to have 'c' run clippy on only the default target
+f = "job:fix"
+l = "job:lint"


### PR DESCRIPTION
Configure bacon to run lints through our `bin/lint` script, instead of using custom `clippy` commands. I also removed the `pedantic` task because I don't think we're using it (I run it and it printed a lot of offenses).