### PR TITLE
Fix TOCTOU issue when creating binstub dir

### DIFF
--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -1132,10 +1132,7 @@ fn install_binstub(gemspec: &GemSpecification, args: &CiInnerArgs) -> Result<()>
     }
 
     let binstub_dir = &args.install_layout.binstub_dir();
-
-    if !binstub_dir.exists() {
-        fs_err::create_dir(binstub_dir)?;
-    }
+    fs_err::create_dir_all(binstub_dir)?;
 
     let ruby_executable_path = &args.ruby_executable_path;
 


### PR DESCRIPTION
We run into [this error](https://github.com/spinel-coop/rv/actions/runs/22615810014/job/65528382466) in the first merge after introducing #570:

> Error: CiError(Io(Custom { kind: AlreadyExists, error: Error { kind: CreateDir, source: Os { code: 17, kind: AlreadyExists, message: "File exists" }, path: "/home/runner/work/rv/rv/brew/Library/Homebrew/vendor/bundle/ruby/3.4.0/bin" } }))

It's probably a race condition and that's why CI did not catch it in the first place.

I believe `fs_err::create_dir_all` should not have this problem.