### PR TITLE
fix(ci): enable GitHub attestations for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,10 @@ jobs:
       CODESIGN_CERTIFICATE: ${{ secrets.CODESIGN_CERTIFICATE }}
       CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
       CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+    permissions:
+      "attestations": "write"
+      "contents": "read"
+      "id-token": "write"
     steps:
       - name: enable windows longpaths
         run: |
@@ -147,6 +151,10 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
+      - name: Attest
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -29,7 +29,7 @@ precise-builds = true
 # Whether to sign macOS executables
 macos-sign = true
 # Provide sigstore attestations from GitHub
-github-attestions = true
+github-attestations = true
 
 # Which binaries to include per target platform
 [dist.binaries]
@@ -49,3 +49,4 @@ aarch64-pc-windows-msvc = "windows-11-arm"
 "actions/checkout" = "v6"
 "actions/upload-artifact" = "v5"
 "actions/download-artifact" = "v6"
+"actions/attest-build-provenance" = "v3"


### PR DESCRIPTION
## Summary

A typo in `dist-workspace.toml` (`github-attestions` instead of `github-attestations`) caused cargo-dist to silently ignore the setting. No Sigstore attestations or SLSA provenance have been generated for any release to date, despite the intended configuration.

This fixes the typo, adds `actions/attest-build-provenance` at v3, and regenerates the release workflow with `dist generate-ci`.