### PR TITLE
Add dist plan check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,25 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-release:
+    name: Check release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install dist
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+
+      - name: Run dist plan
+        run: |
+          dist plan --output-format=json > plan-dist-manifest.json
+          echo "dist plan completed successfully"
+          cat plan-dist-manifest.json
+
   cargo-deny:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary

- Add a `check-release` job to `test.yml` that installs `cargo-dist` and runs `dist plan --output-format=json`
- Fails early if release configuration is broken

## Why

Catches release/config drift during normal CI instead of waiting for release workflow runs. Inspired in part by #576, where a typo in `dist-workspace.toml` was silently ignored. While this check wouldn't have caught that specific typo (cargo-dist silently ignored it), it validates that `dist plan` succeeds against the current configuration.

Modeled after uv's [check-release workflow](https://github.com/astral-sh/uv/blob/c021be36ab26353cf8732aa77f4e34d6e1752393/.github/workflows/check-release.yml).