### PR TITLE
Fix ruby-dev updates

### DIFF
--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -40,6 +40,8 @@ pub enum Error {
         status: reqwest::StatusCode,
         body: String,
     },
+    #[error("Could not get latest ruby-dev release")]
+    GetLatestDevReleaseFailed,
     #[error("Failed to unpack archive path {0}")]
     InvalidTarballPath(PathBuf),
     #[error(transparent)]
@@ -99,7 +101,11 @@ async fn download_tarball(
     progress: &WorkProgress,
 ) -> Result<Utf8PathBuf> {
     let host = HostPlatform::current()?;
-    let url = ruby_url(version, &host);
+    let mut url = ruby_url(version, &host);
+
+    if version.is_dev() && !host.is_windows() {
+        url = find_latest_ruby_dev_url(&url).await?;
+    }
     let archive_path = archive_cache_path(config, &url, &host);
 
     let cache_dir = archive_path.parent().unwrap();
@@ -157,6 +163,23 @@ fn download_path_for(version: &RubyVersion, host: &HostPlatform) -> String {
         }
     } else {
         format!("{version}.{arch}.{ext}")
+    }
+}
+
+async fn find_latest_ruby_dev_url(url: &str) -> Result<String> {
+    let redirects = false;
+    let response = fetch_url(url, redirects).await?;
+
+    if response.status() == StatusCode::FOUND {
+        Ok(response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .expect("a redirect response should have a location header")
+            .to_str()
+            .expect("location header should be a valid UTF-8 string")
+            .to_string())
+    } else {
+        Err(Error::GetLatestDevReleaseFailed)
     }
 }
 
@@ -228,22 +251,9 @@ async fn download_ruby_archive(
     host: &HostPlatform,
 ) -> Result<()> {
     debug!("Downloading archive from {url}");
-    // Build the request with optional GitHub authentication
-    let client = reqwest::Client::new();
-    let mut request_builder = client.get(url);
+    let redirects = true;
+    let response = fetch_url(url, redirects).await?;
 
-    // Add GitHub token authentication if available and URL is from GitHub
-    // Check GITHUB_TOKEN first (GitHub Actions), then GH_TOKEN (GitHub CLI/general use)
-    if crate::config::github::is_github_url(url) {
-        if let Some(token) = crate::config::github::github_token() {
-            debug!("Using authenticated GitHub request for archive download");
-            request_builder = request_builder.header("Authorization", format!("Bearer {}", token));
-        } else {
-            debug!("No GitHub token found, using unauthenticated request for archive download");
-        }
-    }
-    // Start downloading the archive.
-    let response = request_builder.send().await?;
     if !response.status().is_success() {
         let status = response.status();
         if status == StatusCode::NOT_FOUND {
@@ -288,6 +298,32 @@ async fn download_ruby_archive(
     }
 
     Ok(())
+}
+
+async fn fetch_url(url: &str, redirects: bool) -> Result<reqwest::Response> {
+    // Build the request with optional GitHub authentication
+    let client = if !redirects {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?
+    } else {
+        reqwest::Client::new()
+    };
+
+    let mut request_builder = client.get(url);
+
+    // Add GitHub token authentication if available and URL is from GitHub
+    // Check GITHUB_TOKEN first (GitHub Actions), then GH_TOKEN (GitHub CLI/general use)
+    if crate::config::github::is_github_url(url) {
+        if let Some(token) = crate::config::github::github_token() {
+            debug!("Using authenticated GitHub request for archive download");
+            request_builder = request_builder.header("Authorization", format!("Bearer {}", token));
+        } else {
+            debug!("No GitHub token found, using unauthenticated request for archive download");
+        }
+    }
+
+    Ok(request_builder.send().await?)
 }
 
 fn extract_ruby_archive(

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -346,6 +346,22 @@ impl RvTest {
         self.mock_tarball_download(&path, &content)
     }
 
+    /// Mock a ruby dev tarball download for testing
+    pub fn mock_ruby_dev_download(&mut self) -> (Mock, Mock) {
+        let path = self.ruby_dev_tarball_download_path();
+        let redirect_url = self.ruby_dev_tarball_redirect_url();
+        let redirect_path = self.ruby_dev_tarball_redirect_path();
+        let redirect_mock = self
+            .mock_dev_tarball_redirect(&path, &redirect_url)
+            .create();
+        let content = self.create_mock_tarball("dev");
+        let download_mock = self
+            .mock_tarball_download(&redirect_path, &content)
+            .create();
+
+        (redirect_mock, download_mock)
+    }
+
     pub fn mock_gem_download(&mut self, package: &str) -> Mock {
         let path = self.gem_package_download_path(package);
         let content = fs_err::read(format!("../rv-gem-package/tests/fixtures/{package}")).unwrap();
@@ -359,6 +375,13 @@ impl RvTest {
             .with_status(200)
             .with_header("content-type", "application/gzip")
             .with_body(content)
+    }
+
+    pub fn mock_dev_tarball_redirect(&mut self, path: &str, location: &str) -> Mock {
+        self.server
+            .mock("GET", path)
+            .with_status(302)
+            .with_header("location", location)
     }
 
     pub fn mock_info_endpoint(&mut self, name: &str, content: &[u8]) -> Mock {
@@ -443,9 +466,26 @@ impl RvTest {
         )
     }
 
+    pub fn ruby_dev_tarball_redirect_url(&self) -> String {
+        format!(
+            "{}{}",
+            self.server_url(),
+            self.ruby_dev_tarball_redirect_path()
+        )
+    }
+
     pub fn ruby_tarball_download_path(&self, version: &str) -> String {
         let filename = self.make_tarball_file_name(version);
         format!("/latest/download/{filename}")
+    }
+
+    pub fn ruby_dev_tarball_download_path(&self) -> String {
+        let filename = self.make_dev_tarball_file_name();
+        format!("/latest/download/{filename}")
+    }
+    pub fn ruby_dev_tarball_redirect_path(&self) -> String {
+        let filename = self.make_dev_tarball_file_name();
+        format!("/download/20260305/{filename}")
     }
 
     pub fn gem_package_download_path(&self, package: &str) -> String {
@@ -587,6 +627,11 @@ impl RvTest {
     fn make_tarball_file_name(&self, version: &str) -> String {
         let suffix = self.make_platform_suffix();
         format!("ruby-{version}.{suffix}.tar.gz")
+    }
+
+    fn make_dev_tarball_file_name(&self) -> String {
+        let suffix = self.make_platform_suffix();
+        format!("ruby-dev.{suffix}.tar.gz")
     }
 
     /// Returns the ruby arch string matching the default test platform (`MacosAarch64`).

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -346,3 +346,28 @@ fn test_ruby_install_with_latest() {
         .join(format!("{}.tar.gz", cache_key));
     assert!(tarball_path.exists(), "Tarball should be cached");
 }
+
+#[test]
+fn test_ruby_install_with_dev() {
+    let mut test = RvTest::new();
+
+    let (redirect_mock, download_mock) = test.mock_ruby_dev_download();
+
+    let cache_dir = test.enable_cache();
+
+    let output = test.rv(&["ruby", "install", "dev"]);
+
+    redirect_mock.assert();
+    download_mock.assert();
+    output.assert_success();
+    output.assert_stdout_contains(
+        "Installed Ruby version ruby-dev to /tmp/home/.local/share/rv/rubies",
+    );
+
+    let cache_key = rv_cache::cache_digest(test.ruby_dev_tarball_redirect_url());
+    let tarball_path = cache_dir
+        .join("ruby-v0")
+        .join("tarballs")
+        .join(format!("{}.tar.gz", cache_key));
+    assert!(tarball_path.exists(), "Tarball should be cached");
+}


### PR DESCRIPTION
When we fetch `https://github.com/spinel-coop/rv-ruby-dev/releases/latest/download/<name>.tar.gz`, that actually redirects to `https://github.com/spinel-coop/rv-ruby-dev/releases/download/20260305/<name>.tag.gz`.

We can handle the redirection manually and cache based on the second URL, so it's properly expired once there's a new daily build available.