### PR TITLE
Remove unnecessary lint skips

### DIFF
--- a/crates/rv-gem-package/src/error.rs
+++ b/crates/rv-gem-package/src/error.rs
@@ -1,6 +1,3 @@
-// https://github.com/zkat/miette/issues/458
-#![expect(unused_assignments, reason = "miette macros trigger false positives")]
-
 use miette::Diagnostic;
 use std::io;
 use thiserror::Error;

--- a/crates/rv-gem-specification-yaml/src/lib.rs
+++ b/crates/rv-gem-specification-yaml/src/lib.rs
@@ -1,6 +1,3 @@
-// https://github.com/zkat/miette/issues/458
-#![expect(unused_assignments, reason = "miette macros trigger false positives")]
-
 //! # rv-gem-specification-yaml
 //!
 //! A Rust library for parsing and serializing Ruby gem specification YAML files.

--- a/crates/rv-gem-specification-yaml/src/parser/error.rs
+++ b/crates/rv-gem-specification-yaml/src/parser/error.rs
@@ -1,6 +1,3 @@
-// https://github.com/zkat/miette/issues/458
-#![expect(unused_assignments, reason = "miette macros trigger false positives")]
-
 use miette::{Diagnostic, SourceSpan};
 
 #[derive(Debug, thiserror::Error, Diagnostic)]

--- a/crates/rv-lockfile/src/lib.rs
+++ b/crates/rv-lockfile/src/lib.rs
@@ -1,6 +1,3 @@
-// https://github.com/zkat/miette/issues/458
-#![expect(unused_assignments, reason = "miette macros trigger false positives")]
-
 pub mod datatypes;
 mod parser;
 #[cfg(test)]


### PR DESCRIPTION
These are indeed necessary for the lint task to pass in 1.93.0. But I'm not getting any errors in 1.93.1 or above, even if the linked issue is still opened.