### PR TITLE
Ignore lockfile parse errors when discovering ruby versions

### DIFF
--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -12,7 +12,7 @@ use tracing::{debug, instrument};
 use rv_ruby::{
     Ruby,
     request::{RequestError, RubyRequest, Source},
-    version::{ParseVersionError, ReleasedRubyVersion, RubyVersion},
+    version::{ReleasedRubyVersion, RubyVersion},
 };
 
 use crate::GlobalArgs;
@@ -36,10 +36,6 @@ pub enum Error {
     EnvError(#[from] env::VarError),
     #[error(transparent)]
     JoinPathsError(#[from] JoinPathsError),
-    #[error("Tried to parse ruby version from Gemfile.lock, but that file was invalid: {0}")]
-    CouldNotParseGemfileLock(#[from] rv_lockfile::ParseErrors),
-    #[error("Could not parse ruby version from Gemfile.lock: {0}")]
-    CouldNotParseGemfileLockVersion(ParseVersionError),
     #[error("no matching ruby version found")]
     NoMatchingRuby,
 }
@@ -397,13 +393,25 @@ fn find_directory_ruby(dir: &Utf8PathBuf) -> Result<Option<(RubyRequest, Source)
         let raw_contents = std::fs::read_to_string(&lockfile)?;
         // Normalize Windows line endings (CRLF) to Unix (LF) for the parser
         let lockfile_contents = rv_lockfile::normalize_line_endings(&raw_contents);
-        let lockfile_ruby = rv_lockfile::parse(&lockfile_contents)
-            .map_err(Error::CouldNotParseGemfileLock)?
-            .ruby_version;
-        if let Some(lockfile_ruby) = lockfile_ruby {
-            let version = ReleasedRubyVersion::from_gemfile_lock(lockfile_ruby)
-                .map_err(Error::CouldNotParseGemfileLockVersion)?;
-            return Ok(Some((version.into(), Source::GemfileLock(lockfile))));
+
+        if let Ok(parsed_lockfile) = rv_lockfile::parse(&lockfile_contents) {
+            let lockfile_ruby = parsed_lockfile.ruby_version;
+
+            if let Some(lockfile_ruby) = lockfile_ruby {
+                if let Ok(version) = ReleasedRubyVersion::from_gemfile_lock(lockfile_ruby) {
+                    return Ok(Some((version.into(), Source::GemfileLock(lockfile))));
+                } else {
+                    debug!(
+                        "Ignoring ruby version in {} because it could not be parsed",
+                        lockfile
+                    );
+                }
+            }
+        } else {
+            debug!(
+                "Ignoring {} while discovering ruby version to use because it could not be parsed",
+                lockfile
+            );
         }
     }
 


### PR DESCRIPTION
Some rv commands don't really need a lockfile, yet they'd be faced with not really actionable errors if they find an unparseable lockfile.

I think it's better to ignore those errors, and let rv properly yell when an actual command, like `rv clean-install` really needs parsing them to actually work.