### PR TITLE
Replace `dtolnay/rust-toolchain` action with `rustup show`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,8 @@ jobs:
         run: |
           $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
           Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows-arm
-          $outputDir = Join-Path $Env:CARGO_HOME "bin"
+          $cargoHome = if ($Env:CARGO_HOME) { $Env:CARGO_HOME } else { Join-Path $Env:USERPROFILE ".cargo" }
+          $outputDir = Join-Path $cargoHome "bin"
           $tmp | Expand-Archive -DestinationPath $outputDir -Force
           $tmp | Remove-Item
         if: matrix.runs-on == 'windows-11-arm'


### PR DESCRIPTION
Replaces `dtolnay/rust-toolchain@stable` with `rustup show`, which installs the toolchain from `rust-toolchain.toml` directly. Follows up on https://github.com/spinel-coop/rv/pull/593#issuecomment-4020072119.

- Eliminates the `dtolnay/rust-toolchain` third-party dependency
- Currently, the action installs latest stable (1.94.0), but cargo ignores it in favor of
the 1.93.1 pinned in `rust-toolchain.toml`
- Adds `CARGO_INCREMENTAL: 0` to disable incremental compilation in CI, where builds always
start clean and the cached artifacts are never reused.
- Adds a `CARGO_HOME` fallback in the `windows-11-arm` nextest workaround

The last two compensate for side-effects of the removed action: `dtolnay/rust-toolchain` exported both `CARGO_INCREMENTAL=0` and `CARGO_HOME` into `GITHUB_ENV` as part of its setup. `CARGO_INCREMENTAL` affects all runners; `CARGO_HOME` only affected `windows-11-arm`, where the runner image doesn't set it by default.