### PR TITLE
Add dependabot cooldown for rust-toolchain updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,6 +21,8 @@ updates:
       time: "09:00"
       timezone: "America/Los_Angeles"
   - package-ecosystem: "rust-toolchain"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Matches existing configured cooldowns for other ecosystems to minimize supply-chain security vulnerabilities. (["We should all be using dependency cooldowns"](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) makes a comprehensive and excellent case for the merits of cooldowns generally.)