### PR TITLE
Allow params on bin/install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,4 +2,4 @@
 set -euo pipefail
 set -x
 
-cargo install --path crates/rv --locked
+cargo install --path crates/rv --locked "$@"


### PR DESCRIPTION
Sometimes I am facing this:

```
❯ bin/install 
+ cargo install --path crates/rv --locked
error: binary `rv` already exists in destination
binary `rvx` already exists in destination
Add --force to overwrite
```
Currently, this don't work:
```
❯ bin/install --force
```

But with the change in this PR it works. And we can add any other flag if it is needed.