### PR TITLE
Fix activating ruby-dev

### DIFF
--- a/crates/rv-ruby/src/request.rs
+++ b/crates/rv-ruby/src/request.rs
@@ -115,6 +115,12 @@ impl RubyRequest {
     }
 }
 
+impl ReleasedRubyRequest {
+    pub fn is_dev(&self) -> bool {
+        self.prerelease == Some("dev".to_string())
+    }
+}
+
 impl FromStr for ReleasedRubyRequest {
     type Err = RequestError;
     fn from_str(input: &str) -> Result<Self, Self::Err> {

--- a/crates/rv-ruby/src/version.rs
+++ b/crates/rv-ruby/src/version.rs
@@ -33,7 +33,7 @@ impl RubyVersion {
     pub fn satisfies(&self, request: &RubyRequest) -> bool {
         match (self, request) {
             (RubyVersion::Dev, RubyRequest::Dev) => true,
-            (RubyVersion::Dev, RubyRequest::Released(_)) => false,
+            (RubyVersion::Dev, RubyRequest::Released(req)) => req.is_dev(),
             (RubyVersion::Released(version), request) => version.satisfies(request),
         }
     }

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -498,7 +498,12 @@ impl RvTest {
     }
 
     pub fn create_ruby_dir(&self, name: &str) -> Utf8PathBuf {
-        let ruby_dir = self.rubies_dir().join(name);
+        let dir_name = if name.ends_with("dev") {
+            "ruby-dev"
+        } else {
+            name
+        };
+        let ruby_dir = self.rubies_dir().join(dir_name);
         std::fs::create_dir_all(&ruby_dir).expect("Failed to create ruby directory");
 
         let bin_dir = ruby_dir.join("bin");

--- a/crates/rv/tests/integration_tests/shell/env_test.rs
+++ b/crates/rv/tests/integration_tests/shell/env_test.rs
@@ -134,6 +134,29 @@ fn test_shell_env_fallback_to_highest_installed_ruby_if_no_rubies_matching_pin_i
     output.assert_stdout_contains(&format!("export PATH='{expected_path}'"));
 }
 
+#[test]
+fn test_shell_env_pinned_to_dev() {
+    let mut test = RvTest::new();
+    test.env.insert("PATH".into(), "/tmp/bin".into());
+    test.create_ruby_dir("ruby-4.1.0-dev");
+
+    let project_dir = test.temp_root().join("project");
+    std::fs::create_dir_all(project_dir.as_path()).unwrap();
+    std::fs::write(project_dir.join(".ruby-version"), b"4.1.0-dev").unwrap();
+    test.cwd = project_dir;
+
+    let expected_path = [
+        "/tmp/home/.local/share/rv/gems/ruby/4.1.0/bin",
+        "/tmp/home/.local/share/rv/rubies/ruby-dev/lib/ruby/gems/4.1.0/bin",
+        "/tmp/home/.local/share/rv/rubies/ruby-dev/bin",
+        "/tmp/bin",
+    ]
+    .join(":");
+    let output = test.rv(&["shell", "env", "zsh"]);
+    output.assert_success();
+    output.assert_stdout_contains(&format!("export PATH='{expected_path}'"));
+}
+
 // MANPATH is a Unix concept — on Windows, the #[cfg(not(windows))] guard in config.rs
 // means MANPATH is never exported. These tests use dual inline snapshots so the Ruby
 // env setup (RUBY_ROOT, GEM_HOME, PATH, etc.) is verified on ALL platforms.


### PR DESCRIPTION
Currently you can install `ruby-dev`, but `rv` was unable to activate it. This PR fixes the problem.