### PR TITLE
docs: add rv settings configs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,44 @@ See [SHELL INTEGRATION](docs/SHELL_INTEGRATION.md) for more about `.ruby-version
 
 For details, see [INSTALL_BENCHMARK.md](docs/INSTALL_BENCHMARK.md).
 
+## Configuration
+
+`rv` supports configuration via a KDL file named `rv.kdl` located in one of several places. **Only one such file should exist at each level (project or global) for avoid conflicts**.
+
+- Project directories:
+  - `./rv.kdl`
+  - `./.config/rv.kdl`
+  - `./.config/rv/rv.kdl`
+- User global config directories:
+  - `~/.rv.kdl`
+  - `~/.config/rv.kdl`
+  - `~/.config/rv/rv.kdl`
+
+Configuration keys are declared under a root `rv` node.
+
+Example configuration file with allowed settings:
+
+```kdl
+rv {
+  install-path "/custom/install/path"
+  update-mode "install"
+}
+```
+
+### Settings
+
+| Setting        | Description                                             | Default                                    | Allowed values                     |
+| -------------- | ------------------------------------------------------- | ------------------------------------------ | ---------------------------------- |
+| `install-path` | Custom path where `rv` installs Ruby versions and gems. | Bundler configuration or Ruby install dir. | Any valid filesystem path          |
+| `update-mode`  | Controls how `rv` handles updates.                      | `"install"`                                | `"none"`, `"warning"`, `"install"` |
+
+### Environment variables
+
+You can also override settings by environment variables prefixed with `RV_`. For example:
+
+- `RV_INSTALL_PATH` sets the install path.
+- `RV_UPDATE_MODE` sets the update mode.
+
 ## Testimonials
 
 "what the heckie that just installed a ruby version for me in .22 seconds???"

--- a/README.md
+++ b/README.md
@@ -61,41 +61,9 @@ For details, see [INSTALL_BENCHMARK.md](docs/INSTALL_BENCHMARK.md).
 
 ## Configuration
 
-`rv` supports configuration via a KDL file named `rv.kdl` located in one of several places. **Only one such file should exist at each level (project or global) for avoid conflicts**.
+`rv` supports configuration via a `rv.kdl` file at the project or user level, and via environment variables prefixed with `RV_`.
 
-- Project directories:
-  - `./rv.kdl`
-  - `./.config/rv.kdl`
-  - `./.config/rv/rv.kdl`
-- User global config directories:
-  - `~/.rv.kdl`
-  - `~/.config/rv.kdl`
-  - `~/.config/rv/rv.kdl`
-
-Configuration keys are declared under a root `rv` node.
-
-Example configuration file with allowed settings:
-
-```kdl
-rv {
-  install-path "/custom/install/path"
-  update-mode "install"
-}
-```
-
-### Settings
-
-| Setting        | Description                                             | Default                                    | Allowed values                     |
-| -------------- | ------------------------------------------------------- | ------------------------------------------ | ---------------------------------- |
-| `install-path` | Custom path where `rv` installs Ruby versions and gems. | Bundler configuration or Ruby install dir. | Any valid filesystem path          |
-| `update-mode`  | Controls how `rv` handles updates.                      | `"install"`                                | `"none"`, `"warning"`, `"install"` |
-
-### Environment variables
-
-You can also override settings by environment variables prefixed with `RV_`. For example:
-
-- `RV_INSTALL_PATH` sets the install path.
-- `RV_UPDATE_MODE` sets the update mode.
+See [SETTINGS.md](docs/SETTINGS.md) for all settings, allowed values, and configuration precedence.
 
 ## Testimonials
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,71 @@
+# `rv` Settings
+
+This document describes all configuration settings supported by `rv`, how each one is resolved, and how configuration precedence works.
+
+Example `rv.kdl`:
+
+```kdl
+rv {
+  install-path "/custom/gems"
+  update-mode "warning"
+}
+```
+
+## Configuration precedence
+
+When the same setting is defined in multiple places, `rv` resolves it in the following order (highest to lowest priority):
+
+1. **Environment variables** (e.g. `RV_INSTALL_PATH`)
+2. **Project-level config** (`./rv.kdl`, `./.config/rv.kdl`, or `./.config/rv/rv.kdl`)
+3. **Global user config** (`~/.rv.kdl`, `~/.config/rv.kdl`, or `~/.config/rv/rv.kdl`)
+
+In other words: **ENV overrides local, local overrides global.**
+
+---
+
+## `install-path`
+
+**Description:** Custom path where `rv` installs gems.
+
+**Default:** Resolved in the following order:
+
+1. Bundler's configured `path` (e.g. from `.bundle/config` or `BUNDLE_PATH`).
+2. The default `GEM_HOME` of the currently active Ruby version.
+
+**Allowed values:** Any valid filesystem path.
+
+**Example:**
+
+```kdl
+rv {
+  install-path "/custom/gems"
+}
+```
+
+**Environment variable override:** `RV_INSTALL_PATH`
+
+---
+
+## `update-mode`
+
+**Description:** Controls how `rv` handles updating itself.
+
+**Default:** `"install"`
+
+**Allowed values:**
+
+| Value | Behaviour |
+| --------- | ----------------------------------------------------------------- |
+| `"none"` | `rv` never updates itself automatically. Updates are ignored. |
+| `"warning"` | `rv` notifies you when a new version is available but does not install it. |
+| `"install"` | `rv` automatically downloads and installs updates when available. |
+
+**Example:**
+
+```kdl
+rv {
+  update-mode "warning"
+}
+```
+
+**Environment variable override:** `RV_UPDATE_MODE`


### PR DESCRIPTION
I just notice we introduce the settings, but users will not know how to use it.

I don't like READMEs very longs. What do you think about add documentation to `rv` using a tool like [mdbook](https://rust-lang.github.io/mdBook/) and point the domain rv.dev to that documentation? (I just mention mdbook because I use that but could be any similar tool)

Well this is just an idea. Currently, there is no much more info to add. But eventually it will grow.

Edit: if you want to modify no problem. I just generated it quick with llm and modified some parts.