### PR TITLE
Fix `bin/build` after reqwest upgrade merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -984,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 


### PR DESCRIPTION
I'm not sure why the lockfile that got merged was incorrect, but the `--locked` flag our `bin/build` script uses of course does not like it. This should fix it.