### PR TITLE
rvx namespace syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,7 +1860,8 @@ dependencies = [
 [[package]]
 name = "kdl"
 version = "6.7.1"
-source = "git+https://github.com/kdl-org/kdl-rs.git#ce82d2ce3e827eddc6bbb4ec4c315aaf6f9adc08"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082ddf81b2acd76fe04412655d17befedfff1837db772f8e74c38050d25ed670"
 dependencies = [
  "miette",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -655,7 +655,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1060,7 +1060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2116,7 +2116,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2807,7 +2807,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2865,7 +2865,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3447,7 +3447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3575,7 +3575,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3585,7 +3585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4280,7 +4280,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,28 +2439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,7 +3523,8 @@ dependencies = [
 [[package]]
 name = "tabled"
 version = "0.21.0"
-source = "git+https://github.com/shrey4796/tabled.git?branch=drop-proc-macro-error2#70c814c43b196d6b0d565de944b1e556add57d3e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "ansi-str",
  "ansitok",
@@ -3557,11 +3536,9 @@ dependencies = [
 [[package]]
 name = "tabled_derive"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+source = "git+https://github.com/shrey4796/tabled.git?branch=drop-proc-macro-error2#70c814c43b196d6b0d565de944b1e556add57d3e"
 dependencies = [
  "heck",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,6 @@ debug = true
 dbg_macro = "warn"
 redundant_clone = "warn"
 result_large_err = "allow"
+
+[patch.crates-io]
+tabled_derive = { git = "https://github.com/shrey4796/tabled.git", branch = "drop-proc-macro-error2" }

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -4,60 +4,60 @@ set -euo pipefail
 RUBY_VERSION="3.4.7"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-RV="$SCRIPT_DIR/../target/debug/rv"
+RV="cargo run --"
 
 echo "=== rv run --ruby $RUBY_VERSION ruby (install + execute) ==="
-output=$("$RV" run --ruby "$RUBY_VERSION" ruby -e 'puts RUBY_DESCRIPTION')
+output=$($RV run --ruby "$RUBY_VERSION" ruby -e 'puts RUBY_DESCRIPTION')
 echo "  $output"
 echo "$output" | grep -q "$RUBY_VERSION"
 echo "PASS: rv run ruby installed and executed Ruby $RUBY_VERSION"
 
 echo "=== rv ruby list --installed-only ==="
-list=$("$RV" ruby list --installed-only)
+list=$($RV ruby list --installed-only)
 echo "$list"
 echo "$list" | grep -q "$RUBY_VERSION"
 echo "PASS: rv ruby list shows installed $RUBY_VERSION"
 
 echo ""
 echo "=== rv ruby list --installed-only --format json ==="
-json=$("$RV" ruby list --installed-only --format json)
+json=$($RV ruby list --installed-only --format json)
 echo "$json"
 echo "$json" | grep -q '"version"'
 echo "PASS: rv ruby list --format json outputs valid JSON"
 
 echo "=== rv ruby find $RUBY_VERSION ==="
-find_output=$("$RV" ruby find "$RUBY_VERSION")
+find_output=$($RV ruby find "$RUBY_VERSION")
 echo "  $find_output"
 echo "$find_output" | grep -q "ruby"
 echo "PASS: rv ruby find returns a path to ruby"
 
 echo "=== rv ruby pin $RUBY_VERSION ==="
-"$RV" ruby pin "$RUBY_VERSION"
+$RV ruby pin "$RUBY_VERSION"
 pin=$(cat .ruby-version)
 echo "  .ruby-version contains: $pin"
 echo "$pin" | grep -q "$RUBY_VERSION"
 echo "PASS: rv ruby pin writes correct .ruby-version"
 
 echo "=== rv shell env bash ==="
-env_out=$("$RV" shell env bash)
+env_out=$($RV shell env bash)
 echo "$env_out"
 echo "$env_out" | grep -q "RUBY_ROOT"
 echo "$env_out" | grep -q "export PATH="
 echo "PASS: rv shell env bash outputs RUBY_ROOT and PATH exports"
 
 echo "=== rv cache dir ==="
-cache=$("$RV" cache dir)
+cache=$($RV cache dir)
 echo "  $cache"
 [ -n "$cache" ]
 echo "PASS: rv cache dir prints a non-empty path"
 
 echo "=== rv ruby uninstall $RUBY_VERSION ==="
-"$RV" ruby uninstall "$RUBY_VERSION"
+$RV ruby uninstall "$RUBY_VERSION"
 echo "PASS: rv ruby uninstall exits without error"
 
 echo ""
 echo "=== Verify $RUBY_VERSION is no longer listed ==="
-list_after=$("$RV" ruby list --installed-only 2>/dev/null || true)
+list_after=$($RV ruby list --installed-only 2>/dev/null || true)
 if echo "$list_after" | grep -q "$RUBY_VERSION.*installed"; then
   echo "FAIL: $RUBY_VERSION still appears as installed after uninstall"
   exit 1
@@ -66,7 +66,7 @@ echo "PASS: $RUBY_VERSION no longer listed after uninstall"
 
 echo ""
 echo "=== rv run --ruby $RUBY_VERSION ruby (re-install after uninstall) ==="
-"$RV" run --ruby "$RUBY_VERSION" ruby -e 'puts "re-installed"' | grep -q "re-installed"
+$RV run --ruby "$RUBY_VERSION" ruby -e 'puts "re-installed"' | grep -q "re-installed"
 echo "PASS: re-installs and runs after uninstall"
 
 # Clean up .ruby-version left by ruby-pin.sh

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -78,7 +78,7 @@ config = { version = "0.15.22", default-features = false, features = [
   "yaml",
   "convert-case",
 ] }
-kdl = { git = "https://github.com/kdl-org/kdl-rs.git", version = "6.5.0" }
+kdl = { version = "6.7.0" }
 which = "8.0.2"
 shell-quote = { version = "0.7.2", features = ["bash", "fish", "sh"], default-features = false }
 

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -73,7 +73,7 @@ glob = "0.3.3"
 base64 = "0.22.1"
 dep-graph = { workspace = true }
 pubgrub = { workspace = true }
-tabled = { version = "0.21.0", features = ["ansi"], git = "https://github.com/shrey4796/tabled.git", branch = "drop-proc-macro-error2" }
+tabled = { version = "0.21.0", features = ["ansi"] }
 config = { version = "0.15.22", default-features = false, features = [
   "yaml",
   "convert-case",

--- a/crates/rv/src/commands/ruby/list.rs
+++ b/crates/rv/src/commands/ruby/list.rs
@@ -313,7 +313,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_list() {
-        let global_args = global_args().unwrap();
+        let mut global_args = global_args().unwrap();
+        global_args.offline = true;
         let version_filter = VersionFilter {
             all: false,
             installed_only: false,

--- a/crates/rv/src/commands/tool.rs
+++ b/crates/rv/src/commands/tool.rs
@@ -15,22 +15,26 @@ pub struct ToolArgs {
     pub command: ToolCommand,
 }
 
+#[derive(Args)]
+pub struct InstallArgs {
+    /// What to install. This can either be gem@version, e.g.
+    /// `mygem@2.18.0`, or a gem name like `mygem`, which is equivalent
+    /// to doing `mygem@latest`.
+    #[arg()]
+    gem: String,
+    /// What gem server to use.
+    #[arg(long, default_value = "https://gem.coop/")]
+    gem_server: String,
+    /// If true, and the tool is already installed, reinstall it.
+    /// Otherwise, skip installing if the tool was already installed.
+    #[arg(long, short)]
+    force: bool,
+}
+
 #[derive(Subcommand)]
 pub enum ToolCommand {
     #[command(about = "Install a gem as a CLI tool, with its own dedicated environment")]
-    Install {
-        /// What to install. This can either be gem@version, e.g.
-        /// `mygem@2.18.0`, or a gem name like `mygem`, which is equivalent
-        /// to doing `mygem@latest`.
-        gem: String,
-        /// What gem server to use.
-        #[arg(long, default_value = "https://gem.coop/")]
-        gem_server: String,
-        /// If true, and the tool is already installed, reinstall it.
-        /// Otherwise, skip installing if the tool was already installed.
-        #[arg(long, short)]
-        force: bool,
-    },
+    Install(InstallArgs),
     #[command(about = "List installed tools")]
     List {
         /// Output format for the list
@@ -87,13 +91,9 @@ type Result<T> = miette::Result<T, Error>;
 
 pub(crate) async fn tool(global_args: &GlobalArgs, tool_args: ToolArgs) -> Result<()> {
     match tool_args.command {
-        ToolCommand::Install {
-            gem,
-            gem_server,
-            force,
-        } => {
-            let (gem_server, gem) = parse_namespace(gem_server, gem);
-            install::install(global_args, gem, gem_server, force)
+        ToolCommand::Install(args) => {
+            let (gem_server, gem) = parse_namespace(args.gem_server, args.gem);
+            install::install(global_args, gem, gem_server, args.force)
                 .await
                 .map(|_| ())?
         }

--- a/crates/rv/src/commands/tool.rs
+++ b/crates/rv/src/commands/tool.rs
@@ -91,21 +91,41 @@ pub(crate) async fn tool(global_args: &GlobalArgs, tool_args: ToolArgs) -> Resul
             gem,
             gem_server,
             force,
-        } => install::install(global_args, gem, gem_server, force)
-            .await
-            .map(|_| ())?,
+        } => {
+            let (gem_server, gem) = parse_namespace(gem_server, gem);
+            install::install(global_args, gem, gem_server, force)
+                .await
+                .map(|_| ())?
+        }
         ToolCommand::List { format } => list::list(global_args, format)?,
         ToolCommand::Uninstall { gem } => uninstall::uninstall(global_args, gem)?,
         ToolCommand::Run {
             gem,
             gem_server,
             no_install,
-            args,
-        } => run::run(global_args, gem, gem_server, no_install, args).await?,
+            mut args,
+        } => {
+            let gem = gem
+                .or(args.first().cloned())
+                .expect("gem or first arg is required");
+            let (gem_server, gem) = parse_namespace(gem_server, gem);
+            args[0] = gem.clone();
+            run::run(global_args, Some(gem), gem_server, no_install, args).await?
+        }
         ToolCommand::Dir => dir::dir(global_args)?,
     };
 
     Ok(())
+}
+
+fn parse_namespace(gem_server: String, gem: String) -> (String, String) {
+    if gem.chars().nth(0) == Some('@') {
+        if let Some((namespace, inner_gem)) = gem.split_once('/') {
+            let gem_server = [gem_server, namespace.to_string()].join("/");
+            return (gem_server, inner_gem.to_string());
+        }
+    }
+    (gem_server, gem)
 }
 
 /// The directory where this tool can be found.

--- a/crates/rv/src/commands/tool.rs
+++ b/crates/rv/src/commands/tool.rs
@@ -119,11 +119,11 @@ pub(crate) async fn tool(global_args: &GlobalArgs, tool_args: ToolArgs) -> Resul
 }
 
 fn parse_namespace(gem_server: String, gem: String) -> (String, String) {
-    if gem.chars().nth(0) == Some('@') {
-        if let Some((namespace, inner_gem)) = gem.split_once('/') {
-            let gem_server = [gem_server, namespace.to_string()].join("/");
-            return (gem_server, inner_gem.to_string());
-        }
+    if gem.starts_with('@')
+        && let Some((namespace, inner_gem)) = gem.split_once('/')
+    {
+        let gem_server = [gem_server, namespace.to_string()].join("/");
+        return (gem_server, inner_gem.to_string());
     }
     (gem_server, gem)
 }

--- a/crates/rv/src/commands/tool.rs
+++ b/crates/rv/src/commands/tool.rs
@@ -146,3 +146,23 @@ pub struct Installed {
     /// The dir where the tool/gem was installed.
     pub dir: Utf8PathBuf,
 }
+
+#[test]
+fn test_parse_namespace() {
+    assert_eq!(
+        ("https://gem.coop".to_string(), "indirect".to_string()),
+        parse_namespace("https://gem.coop".to_string(), "indirect".to_string())
+    );
+    assert_eq!(
+        ("gem.coop/@namespace".to_string(), "gemname".to_string()),
+        parse_namespace("gem.coop".to_string(), "@namespace/gemname".to_string())
+    );
+    assert_eq!(
+        ("gem.coop".to_string(), "gemname@latest".to_string()),
+        parse_namespace("gem.coop".to_string(), "gemname@latest".to_string())
+    );
+    assert_eq!(
+        ("gem.coop".to_string(), "gem/name".to_string()),
+        parse_namespace("gem.coop".to_string(), "gem/name".to_string())
+    );
+}

--- a/crates/rv/src/commands/tool.rs
+++ b/crates/rv/src/commands/tool.rs
@@ -165,4 +165,31 @@ fn test_parse_namespace() {
         ("gem.coop".to_string(), "gem/name".to_string()),
         parse_namespace("gem.coop".to_string(), "gem/name".to_string())
     );
+
+    assert_eq!(
+        ("gem.coop".to_string(), "@gemname".to_string()),
+        parse_namespace("gem.coop".to_string(), "@gemname".to_string())
+    );
+    assert_eq!(
+        ("gem.coop/@".to_string(), "gemname".to_string()),
+        parse_namespace("gem.coop".to_string(), "@/gemname".to_string())
+    );
+    assert_eq!(
+        ("gem.coop/@namespace".to_string(), "gem/name".to_string()),
+        parse_namespace("gem.coop".to_string(), "@namespace/gem/name".to_string())
+    );
+    assert_eq!(
+        ("".to_string(), "".to_string()),
+        parse_namespace("".to_string(), "".to_string())
+    );
+    assert_eq!(
+        (
+            "gem.coop/@namespace".to_string(),
+            "gemname@1.2.3".to_string()
+        ),
+        parse_namespace(
+            "gem.coop".to_string(),
+            "@namespace/gemname@1.2.3".to_string()
+        )
+    );
 }

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -64,6 +64,7 @@ pub struct Config {
     pub requested_ruby: RequestedRuby,
     pub bundler_settings: BundlerSettings,
     pub rv_settings: RvSettings,
+    pub offline: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -134,6 +135,7 @@ impl Config {
         let requested_ruby = RequestedRuby::new(request, &home_dir, &project_root)?;
         let bundler_settings = BundlerSettings::default();
         let rv_settings = RvSettings::default();
+        let offline = global_args.offline;
 
         Ok(Self {
             ruby_dirs,
@@ -142,6 +144,7 @@ impl Config {
             requested_ruby,
             bundler_settings,
             rv_settings,
+            offline,
         })
     }
 
@@ -183,6 +186,7 @@ impl Config {
             requested_ruby: RequestedRuby::Global,
             bundler_settings: BundlerSettings::default(),
             rv_settings: RvSettings::default(),
+            offline: false,
         }
     }
 

--- a/crates/rv/src/config/ruby_fetcher.rs
+++ b/crates/rv/src/config/ruby_fetcher.rs
@@ -58,6 +58,11 @@ impl Config {
     /// On Windows, fetches from `oneclick/rubyinstaller2` (one release per Ruby version).
     /// On other platforms, fetches from `spinel-coop/rv-ruby` (all versions in one release).
     pub async fn discover_remote_rubies(&self) -> Vec<RemoteRuby> {
+        if self.offline {
+            debug!("OFFLINE: skipping remote ruby fetch");
+            return vec![];
+        }
+
         // Detect host first — this decides which release source to query.
         let host = match HostPlatform::current() {
             Ok(h) => h,

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -836,6 +836,12 @@ impl RvOutput {
     }
 }
 
+impl Default for RvTest {
+    fn default() -> RvTest {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -293,10 +293,8 @@ fn test_ruby_install_skips_existing_version_and_suggests_force_flag() {
 fn test_ruby_install_invalid_url() {
     let mut test = RvTest::new();
 
-    test.env.insert(
-        "RV_INSTALL_URL".into(),
-        "http://invalid-url-that-does-not-exist.com".into(),
-    );
+    test.env
+        .insert("RV_INSTALL_URL".into(), "http://127.0.0.1:0".into());
 
     let cache_dir = test.enable_cache();
 

--- a/crates/rv/tests/integration_tests/tool_test.rs
+++ b/crates/rv/tests/integration_tests/tool_test.rs
@@ -1,0 +1,4 @@
+mod install_test;
+mod list_test;
+mod run_test;
+mod uninstall_test;

--- a/crates/rv/tests/integration_tests/tool_test/run_test.rs
+++ b/crates/rv/tests/integration_tests/tool_test/run_test.rs
@@ -1,0 +1,85 @@
+use crate::{RvOutput, RvTest};
+
+impl RvTest {
+    pub fn tool_run(&mut self, args: &[&str]) -> RvOutput {
+        self.rv(&[
+            &["tool", "run", "--gem-server", &self.gemserver_url()],
+            args,
+        ]
+        .concat())
+    }
+}
+
+mod test {
+    use owo_colors::OwoColorize as _;
+    use rv_cache::rm_rf;
+
+    use crate::RvTest;
+
+    #[test]
+    fn test_tool_run_works() {
+        let mut test = RvTest::new();
+
+        let releases_mock = test.mock_releases_all_platforms(["4.0.0"].to_vec());
+        let ruby_mock = test.mock_ruby_download("4.0.0").create();
+        let info_endpoint_mock = test.mock_info_endpoint("indirect").create();
+        let tarball_mock = test.mock_gem_download("indirect-1.2.0.gem").create();
+
+        let output = test.tool_run(&["indirect"]);
+
+        let tool_home = "/tmp/home/.local/share/rv/tools/indirect@1.2.0";
+        let expected_info_message = format!(
+            "Installed {} version 1.2.0 to {}",
+            "indirect".cyan(),
+            tool_home.cyan()
+        );
+        output.assert_success();
+        output.assert_stdout_contains(&expected_info_message);
+
+        releases_mock.assert();
+        ruby_mock.assert();
+        info_endpoint_mock.assert();
+        tarball_mock.assert();
+
+        // Manually remove tool
+        rm_rf(test.data_dir().join("rv/tools/indirect@1.2.0")).unwrap();
+    }
+
+    #[test]
+    fn test_tool_run_works_with_namespaced_gem() {
+        let mut test = RvTest::new();
+        test.namespace = Some("@indirect".to_string());
+
+        let releases_mock = test.mock_releases_all_platforms(["4.0.0"].to_vec());
+        let ruby_mock = test.mock_ruby_download("4.0.0").create();
+        let info_endpoint_mock = test.mock_info_endpoint("indirect").create();
+        let tarball_mock = test.mock_gem_download("indirect-1.2.0.gem").create();
+
+        // skip using `tool_run()` specifically so we do not include the namespace
+        // in the gem server URL, and test that it gets added from the gem name.
+        let output = test.rv(&[
+            "tool",
+            "run",
+            "--gem-server",
+            &test.server_url(),
+            "@indirect/indirect",
+        ]);
+
+        let tool_home = "/tmp/home/.local/share/rv/tools/indirect@1.2.0";
+        let expected_info_message = format!(
+            "Installed {} version 1.2.0 to {}",
+            "indirect".cyan(),
+            tool_home.cyan()
+        );
+        output.assert_success();
+        output.assert_stdout_contains(&expected_info_message);
+
+        releases_mock.assert();
+        ruby_mock.assert();
+        info_endpoint_mock.assert();
+        tarball_mock.assert();
+
+        // Manually remove tool
+        rm_rf(test.data_dir().join("rv/tools/indirect@1.2.0")).unwrap();
+    }
+}

--- a/win/test-integration.ps1
+++ b/win/test-integration.ps1
@@ -3,7 +3,7 @@ $RUBY_VERSION = "3.4.7"
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 
-cargo build --bin rvw
+cargo build --bin rvw --bin rvx
 $RV = (Resolve-Path ".\target\debug\rvw.exe").Path
 
 Write-Host "=== rv run --ruby $RUBY_VERSION ruby (install + execute) ==="

--- a/win/test-integration.ps1
+++ b/win/test-integration.ps1
@@ -2,6 +2,8 @@ $RUBY_VERSION = "3.4.7"
 
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
+
+cargo build --bin rvw
 $RV = (Resolve-Path ".\target\debug\rvw.exe").Path
 
 Write-Host "=== rv run --ruby $RUBY_VERSION ruby (install + execute) ==="


### PR DESCRIPTION
This PR adds support for namespaces written in the format `@name/gem`. As a real-world example, with this PR it becomes possible to run `rvx @indirect/indirect` and get the gem `indirect` from the namespace `@indirect`.