### PR TITLE
Workaround issue in actions macos runner image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Workaround for https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
 
       - name: Build rv
         run: bin/build


### PR DESCRIPTION
New macos action images rollout seems to have broken some rust stuff (see https://github.com/actions/runner-images/issues/14097), this is a suggested workaround to fix it (see
https://github.com/Swatinem/rust-cache/issues/341).