### PR TITLE
Build linux-gnu releases on ubuntu-22.04 for glibc 2.35 compat

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -40,8 +40,8 @@ aarch64-pc-windows-msvc = ["rv", "rvx", "rvw"]
 [dist.github-custom-runners]
 x86_64-apple-darwin = "macos-14"
 aarch64-apple-darwin = "macos-14"
-aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
-x86_64-unknown-linux-gnu = "ubuntu-24.04"
+aarch64-unknown-linux-gnu = "ubuntu-22.04-arm"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"
 x86_64-pc-windows-msvc = "windows-latest"
 aarch64-pc-windows-msvc = "windows-11-arm"
 


### PR DESCRIPTION
## Summary

Fixes #698.

The dist build matrix runs the linux-gnu targets on `ubuntu-24.04` (glibc 2.39), so every released binary gets tagged with `GLIBC_2.39` symbols and refuses to start on systems pinned to glibc 2.35–2.38 — Ubuntu 22.04 LTS, Debian 12, RHEL 9, Amazon Linux 2023, and others. `PLANS.md` advertises "Linux (glibc 2.35+)" as supported, so this is a CI/docs mismatch.

Repinning both linux-gnu targets to `ubuntu-22.04` runners aligns the binaries with the documented glibc floor:

```diff
[dist.github-custom-runners]
- aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
- x86_64-unknown-linux-gnu  = "ubuntu-24.04"
+ aarch64-unknown-linux-gnu = "ubuntu-22.04-arm"
+ x86_64-unknown-linux-gnu  = "ubuntu-22.04"
```

## Why it's safe

- Forward compatibility in glibc is unchanged — binaries built against 2.35 continue to run on every glibc ≥ 2.35, including all 24.04+ hosts.
- `ubuntu-22.04` GitHub Actions runners are supported through April 2027.
- No code changes; only the runner image moves.

## Test plan

- [ ] Cut a pre-release / dev build from this branch
- [ ] Confirm `strings rv | grep -oE 'GLIBC_[0-9.]+' | sort -V -u | tail -3` no longer reports `GLIBC_2.39`
- [ ] Confirm the binary starts on Ubuntu 22.04 LTS