### PR TITLE
feat: Add --offline flag and rv vendor for offline gem installs

### DIFF
--- a/crates/rv/src/commands.rs
+++ b/crates/rv/src/commands.rs
@@ -5,3 +5,4 @@ pub mod run;
 pub mod self_cmd;
 pub mod shell;
 pub mod tool;
+pub mod vendor;

--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -222,6 +222,10 @@ pub enum Error {
         "Native gem extensions require a C compiler to build.\nInstall them by running:\n\n  xcode-select --install"
     ))]
     MissingMacosDevTools,
+    #[error(
+        "Cannot download gem {gem_name} from {url} in offline mode: not in the cache. Try again without --offline so rv can fetch the gem."
+    )]
+    OfflineGemMissing { gem_name: String, url: String },
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -1844,6 +1848,11 @@ async fn download_gem<'i>(
         stats.cached_one();
         let data = tokio::fs::read(&cache_path).await?;
         Bytes::from(data)
+    } else if config.offline {
+        return Err(Error::OfflineGemMissing {
+            gem_name: spec.release_tuple.full_name(),
+            url: url.to_string(),
+        });
     } else {
         debug!("Downloading gem from {url}");
         stats.downloaded_one();

--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -1914,6 +1914,17 @@ async fn download_gem<'i>(
         debug!("Cached {}", full_name);
     }
 
+    if config.bundler_settings.cache_all()
+        && let Some(vp) = vendor_path.as_ref()
+        && !vp.exists()
+    {
+        if let Some(parent) = vp.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(vp, &contents).await?;
+        debug!("Vendored {} to {}", full_name, vp);
+    }
+
     Ok(DownloadedRubygems { contents, spec })
 }
 

--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -870,7 +870,7 @@ fn cache_gemspec_path(
     Ok(dep_gemspec)
 }
 
-fn find_lockfile_path(gemfile: &Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {
+pub(crate) fn find_lockfile_path(gemfile: &Option<Utf8PathBuf>) -> Result<Utf8PathBuf> {
     let Some(gemfile) = gemfile else {
         let lockfile_path = rv_dirs::canonicalize_utf8(Utf8Path::new("Gemfile.lock"))
             .map_err(|_| Error::MissingImplicitLockfile)?;
@@ -1776,7 +1776,7 @@ where
     })
 }
 
-fn url_for_spec(remote: &str, spec: &Spec) -> Result<Url> {
+pub(crate) fn url_for_spec(remote: &str, spec: &Spec) -> Result<Url> {
     let package_name = spec.release_tuple.package_name();
     let path = format!("gems/{package_name}");
     let url = url::Url::parse(remote)

--- a/crates/rv/src/commands/clean_install.rs
+++ b/crates/rv/src/commands/clean_install.rs
@@ -1842,8 +1842,18 @@ async fn download_gem<'i>(
         .shard(rv_cache::CacheBucket::Gem, "gems")
         .into_path_buf()
         .join(format!("{cache_key}.gem"));
+    let vendor_path = config
+        .bundler_settings
+        .cache_path()
+        .map(|dir| dir.join(format!("{}.gem", spec.release_tuple.full_name())));
 
-    let contents = if cache_path.exists() {
+    let contents = if let Some(vp) = vendor_path.as_ref()
+        && vp.exists()
+    {
+        debug!("Reusing gem from vendor/cache: {}", vp);
+        stats.cached_one();
+        Bytes::from(tokio::fs::read(vp).await?)
+    } else if cache_path.exists() {
         debug!("Reusing gem from {url} in cache");
         stats.cached_one();
         let data = tokio::fs::read(&cache_path).await?;

--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -45,6 +45,14 @@ pub enum Error {
     InvalidTarballPath(PathBuf),
     #[error(transparent)]
     UnsupportedPlatform(#[from] rv_platform::UnsupportedPlatformError),
+    #[error(
+        "Cannot download Ruby {version} in offline mode: the archive at {url} is not in the cache. Try again without --offline so rv can download it."
+    )]
+    OfflineArchiveMissing { version: String, url: String },
+    #[error(
+        "Cannot resolve the latest ruby-dev release in offline mode. Try again without --offline."
+    )]
+    OfflineDevReleaseLookup,
 }
 
 type Result<T> = miette::Result<T, Error>;
@@ -63,6 +71,18 @@ pub(crate) async fn install(
     let progress = WorkProgress::new();
 
     let request = config.ruby_request();
+
+    if config.offline
+        && !force
+        && let Some(installed) = config.current_ruby()
+    {
+        println!(
+            "Ruby {} already installed at {}.",
+            installed.version.to_string().cyan(),
+            installed.path.cyan(),
+        );
+        return Ok(());
+    }
 
     let version = match request {
         RubyRequest::Dev => "dev".to_string(),
@@ -112,6 +132,9 @@ async fn download_tarball(
     let mut url = ruby_url(version, &host);
 
     if version == "dev" && !host.is_windows() {
+        if config.offline {
+            return Err(Error::OfflineDevReleaseLookup);
+        }
         url = find_latest_ruby_dev_url(&url).await?;
     }
     let archive_path = archive_cache_path(config, &url, &host);
@@ -126,6 +149,11 @@ async fn download_tarball(
             "Archive {} already exists, skipping download.",
             archive_path.cyan()
         );
+    } else if config.offline {
+        return Err(Error::OfflineArchiveMissing {
+            version: version.to_string(),
+            url,
+        });
     } else {
         download_ruby_archive(config, &url, &archive_path, version, progress, &host).await?;
     }

--- a/crates/rv/src/commands/ruby/list.rs
+++ b/crates/rv/src/commands/ruby/list.rs
@@ -153,6 +153,11 @@ pub(crate) async fn list(
     let active_installed = active_ruby;
 
     if !version_filter.installed_only {
+        if config.offline && !config.has_cached_remote_ruby_list() {
+            return Err(Error::ConfigError(
+                crate::config::Error::OfflineRemoteRubyListUnavailable,
+            ));
+        }
         let remote_rubies = config.remote_rubies().await;
 
         let selected_remote_rubies = if version_filter.all {

--- a/crates/rv/src/commands/vendor.rs
+++ b/crates/rv/src/commands/vendor.rs
@@ -1,0 +1,206 @@
+use anstream::println;
+use bytes::Bytes;
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::Args;
+use indicatif::ProgressStyle;
+use owo_colors::OwoColorize;
+use rv_client::http_client::rv_http_client;
+use rv_lockfile::datatypes::ChecksumAlgorithm;
+use sha2::Digest;
+use tracing::{debug, info_span, warn};
+use tracing_indicatif::span_ext::IndicatifSpanExt;
+
+use crate::commands::clean_install::{find_lockfile_path, url_for_spec};
+use crate::{GlobalArgs, config::Config};
+
+#[derive(Args, Debug)]
+pub struct VendorArgs {
+    /// Path to the Gemfile (or directory containing one)
+    #[arg(long, short)]
+    pub gemfile: Option<Utf8PathBuf>,
+}
+
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] crate::config::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Parse(#[from] rv_lockfile::ParseErrors),
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
+    Ci(#[from] crate::commands::clean_install::Error),
+    #[error("Could not determine where to vendor gems")]
+    InvalidVendorPath,
+    #[error("`rv vendor` requires network access. Re-run without --offline.")]
+    OfflineNotSupported,
+    #[error(
+        "File {filename} did not match the {algo} checksum locked for gem {gem_name} in Gemfile.lock"
+    )]
+    LockfileChecksumFail {
+        filename: String,
+        gem_name: String,
+        algo: &'static str,
+    },
+}
+
+type Result<T> = miette::Result<T, Error>;
+
+pub(crate) async fn vendor(global_args: &GlobalArgs, args: VendorArgs) -> Result<()> {
+    let config = Config::with_settings(global_args, None)?;
+
+    if config.offline {
+        return Err(Error::OfflineNotSupported);
+    }
+
+    config.self_update_if_needed().await;
+
+    let lockfile_path = find_lockfile_path(&args.gemfile)?;
+    let raw = tokio::fs::read_to_string(&lockfile_path).await?;
+    let normalized = rv_lockfile::normalize_line_endings(&raw);
+    let lockfile = rv_lockfile::parse(&normalized)?;
+
+    let vendor_dir = config
+        .bundler_settings
+        .cache_path()
+        .ok_or(Error::InvalidVendorPath)?;
+    fs_err::create_dir_all(&vendor_dir)?;
+
+    let client = rv_http_client("vendor")?;
+
+    let span = info_span!("Vendoring gems");
+    span.pb_set_style(
+        &ProgressStyle::with_template("{spinner:.green} {span_name} {pos}/{len} - {msg}").unwrap(),
+    );
+    span.pb_set_length(lockfile.gem_spec_count() as u64);
+    let _guard = span.enter();
+
+    let mut downloaded = 0u64;
+    let mut skipped = 0u64;
+
+    for gem_source in &lockfile.gem {
+        let Some(remote) = gem_source.remote else {
+            debug!("Skipping gem source with no remote");
+            continue;
+        };
+
+        for spec in &gem_source.specs {
+            let filename = spec.release_tuple.package_name();
+            let target = vendor_dir.join(&filename);
+
+            if target.exists() {
+                debug!("{} already vendored, skipping", filename);
+                skipped += 1;
+                span.pb_inc(1);
+                continue;
+            }
+
+            let bytes = fetch_gem(&config, &client, remote, spec).await?;
+            verify_checksum(&bytes, spec, &lockfile, &filename)?;
+            write_atomically(&target, &bytes).await?;
+
+            downloaded += 1;
+            span.pb_inc(1);
+            span.pb_set_message(&filename);
+        }
+    }
+
+    drop(_guard);
+
+    if !lockfile.git.is_empty() || !lockfile.path.is_empty() {
+        warn!("`rv vendor` does not yet handle git or path sources; those gems were skipped.");
+    }
+
+    println!(
+        "Vendored {} gem(s) to {} ({} already present)",
+        downloaded.to_string().cyan(),
+        vendor_dir.cyan(),
+        skipped,
+    );
+
+    Ok(())
+}
+
+/// Fetch a gem's bytes, preferring the user-level rv cache when present so
+/// repeated `rv vendor` runs don't re-download the same archive.
+async fn fetch_gem(
+    config: &Config,
+    client: &reqwest::Client,
+    remote: &str,
+    spec: &rv_lockfile::datatypes::Spec,
+) -> Result<Bytes> {
+    let mut url = url_for_spec(remote, spec)?;
+    let user_cache_path = config
+        .cache
+        .shard(rv_cache::CacheBucket::Gem, "gems")
+        .into_path_buf()
+        .join(format!("{}.gem", rv_cache::cache_digest(url.as_str())));
+
+    if user_cache_path.exists() {
+        debug!("Reusing gem from rv cache: {}", url);
+        return Ok(Bytes::from(tokio::fs::read(&user_cache_path).await?));
+    }
+
+    if let Some(host) = url.host_str()
+        && let Some(token) = config.bundler_settings.token_for(host)
+    {
+        let _ = url.set_username(&token);
+    }
+
+    debug!("Downloading {}", url);
+    let bytes = client
+        .get(url.clone())
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    Ok(bytes)
+}
+
+fn verify_checksum(
+    bytes: &Bytes,
+    spec: &rv_lockfile::datatypes::Spec,
+    lockfile: &rv_lockfile::datatypes::GemfileDotLock<'_>,
+    filename: &str,
+) -> Result<()> {
+    let Some(checksums) = &lockfile.checksums else {
+        return Ok(());
+    };
+    let Some(entry) = checksums
+        .iter()
+        .find(|c| c.release_tuple == spec.release_tuple)
+    else {
+        return Ok(());
+    };
+
+    match entry.algorithm {
+        ChecksumAlgorithm::None => Ok(()),
+        ChecksumAlgorithm::Unknown(other) => {
+            warn!("Unknown checksum algorithm {} for gem {}", other, filename);
+            Ok(())
+        }
+        ChecksumAlgorithm::SHA256 => {
+            let actual = sha2::Sha256::digest(bytes);
+            if actual[..] != entry.value {
+                return Err(Error::LockfileChecksumFail {
+                    filename: filename.to_owned(),
+                    gem_name: spec.release_tuple.full_name(),
+                    algo: "sha256",
+                });
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Write to a sibling `.tmp` file then rename, so an interrupted vendor run
+/// never leaves a half-written `.gem` for the next `rv ci` to find.
+async fn write_atomically(target: &Utf8Path, bytes: &Bytes) -> Result<()> {
+    let tmp = target.with_extension("gem.tmp");
+    tokio::fs::write(&tmp, bytes).await?;
+    tokio::fs::rename(&tmp, target).await?;
+    Ok(())
+}

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -64,6 +64,7 @@ pub struct Config {
     pub requested_ruby: RequestedRuby,
     pub bundler_settings: BundlerSettings,
     pub rv_settings: RvSettings,
+    pub offline: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -142,6 +143,7 @@ impl Config {
             requested_ruby,
             bundler_settings,
             rv_settings,
+            offline: global_args.offline,
         })
     }
 
@@ -183,6 +185,7 @@ impl Config {
             requested_ruby: RequestedRuby::Global,
             bundler_settings: BundlerSettings::default(),
             rv_settings: RvSettings::default(),
+            offline: false,
         }
     }
 

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -167,6 +167,9 @@ impl Config {
     }
 
     pub async fn self_update_if_needed(&self) {
+        if self.offline {
+            return;
+        }
         update::check(&self.rv_settings.update_mode).await;
     }
 

--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -52,6 +52,10 @@ pub enum Error {
         "No available Ruby matched the Ruby requirements. The requirements were {requirement:?}"
     )]
     NoRubyMatchingRequirement { requirement: Requirement },
+    #[error(
+        "Cannot fetch the list of available Ruby versions in offline mode and no cached release list is available. Try again without --offline so rv can populate its cache."
+    )]
+    OfflineRemoteRubyListUnavailable,
 }
 
 type Result<T> = miette::Result<T, Error>;
@@ -208,6 +212,9 @@ impl Config {
             Ok(version)
         } else {
             debug!("Fetching available rubies, because user gave an underspecified Ruby range");
+            if self.offline && !self.has_cached_remote_ruby_list() {
+                return Err(Error::OfflineRemoteRubyListUnavailable);
+            }
             let remote_rubies = self.remote_rubies().await;
 
             let matched_ruby = requested_range
@@ -232,6 +239,9 @@ impl Config {
         match requirement.find_match_in(&installed_rubies, false) {
             Some(local_ruby) => Ok(local_ruby.version),
             None => {
+                if self.offline && !self.has_cached_remote_ruby_list() {
+                    return Err(Error::OfflineRemoteRubyListUnavailable);
+                }
                 let remote_rubies = &self.remote_rubies().await;
 
                 match requirement

--- a/crates/rv/src/config/bundler_settings.rs
+++ b/crates/rv/src/config/bundler_settings.rs
@@ -109,6 +109,25 @@ impl BundlerSettings {
 
         self.get_string(&key)
     }
+
+    /// Whether Bundler's `cache_all` setting is enabled. When true, `rv ci`
+    /// also writes downloaded gems to `vendor/cache/` as a side effect.
+    pub fn cache_all(&self) -> bool {
+        self.get_bool("BUNDLE_CACHE_ALL").unwrap_or(false)
+    }
+
+    /// Directory where vendored `.gem` files live. Defaults to `vendor/cache`
+    /// in the current working directory; can be overridden by
+    /// `BUNDLE_CACHE_PATH` in `.bundle/config`. Relative paths are resolved
+    /// against the cwd to match Bundler's behavior.
+    pub fn cache_path(&self) -> Option<Utf8PathBuf> {
+        let raw = self
+            .get_string("BUNDLE_CACHE_PATH")
+            .unwrap_or_else(|| "vendor/cache".to_string());
+        absolute(&raw)
+            .ok()
+            .and_then(|pb| Utf8PathBuf::from_path_buf(pb).ok())
+    }
 }
 
 #[cfg(test)]
@@ -280,6 +299,66 @@ BUNDLE_DEPLOYMENT: true
         let bundler_settings = BundlerSettings::new(&home_dir, &project_dir).unwrap();
 
         assert_eq!(None, bundler_settings.path())
+    }
+
+    #[test]
+    fn test_cache_all_defaults_to_false() {
+        let temp_dir = Utf8TempDir::new().unwrap();
+        let home_dir = temp_dir.path().join("home");
+        let project_dir = temp_dir.path().join("project");
+
+        let settings = BundlerSettings::new(&home_dir, &project_dir).unwrap();
+        assert!(!settings.cache_all());
+    }
+
+    #[test]
+    fn test_cache_all_from_config() {
+        let temp_dir = Utf8TempDir::new().unwrap();
+        let home_dir = temp_dir.path().join("home");
+        let project_dir = temp_dir.path().join("project");
+
+        let config_dir = project_dir.join(".bundle");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("config"), "---\nBUNDLE_CACHE_ALL: true\n").unwrap();
+
+        let settings = BundlerSettings::new(&home_dir, &project_dir).unwrap();
+        assert!(settings.cache_all());
+    }
+
+    #[test]
+    fn test_cache_path_defaults_to_vendor_cache() {
+        let temp_dir = Utf8TempDir::new().unwrap();
+        let home_dir = temp_dir.path().join("home");
+        let project_dir = temp_dir.path().join("project");
+
+        let settings = BundlerSettings::new(&home_dir, &project_dir).unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            cwd.join("vendor/cache"),
+            settings.cache_path().unwrap().to_string()
+        );
+    }
+
+    #[test]
+    fn test_cache_path_override_from_config() {
+        let temp_dir = Utf8TempDir::new().unwrap();
+        let home_dir = temp_dir.path().join("home");
+        let project_dir = temp_dir.path().join("project");
+
+        let config_dir = project_dir.join(".bundle");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("config"),
+            "---\nBUNDLE_CACHE_PATH: my/cache\n",
+        )
+        .unwrap();
+
+        let settings = BundlerSettings::new(&home_dir, &project_dir).unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            cwd.join("my/cache"),
+            settings.cache_path().unwrap().to_string()
+        );
     }
 
     #[test]

--- a/crates/rv/src/config/ruby_fetcher.rs
+++ b/crates/rv/src/config/ruby_fetcher.rs
@@ -52,13 +52,40 @@ pub enum Error {
 
 type Result<T> = miette::Result<T, Error>;
 
+/// Returns (cache filename, release-list URL) for the given host.
+fn cache_target_for(host: &HostPlatform) -> (&'static str, String) {
+    if host.is_windows() {
+        (
+            "rubyinstaller2.json",
+            url_for(
+                "RV_WINDOWS_LIST_URL",
+                "https://api.github.com/repos/oneclick/rubyinstaller2/releases?per_page=100",
+            ),
+        )
+    } else {
+        (
+            "available_rubies.json",
+            url_for(
+                "RV_LIST_URL",
+                "https://api.github.com/repos/spinel-coop/rv-ruby/releases/latest",
+            ),
+        )
+    }
+}
+
+fn cache_key_for(url: &str, cache_file: &str) -> String {
+    rv_cache::cache_digest(format!("{}-{}", url, cache_file))
+}
+
 impl Config {
     /// Discover all remotely available Ruby versions with caching.
     ///
     /// On Windows, fetches from `oneclick/rubyinstaller2` (one release per Ruby version).
     /// On other platforms, fetches from `spinel-coop/rv-ruby` (all versions in one release).
+    ///
+    /// In offline mode, returns whatever is in the on-disk cache without making
+    /// any network requests; returns an empty list if nothing is cached.
     pub async fn discover_remote_rubies(&self) -> Vec<RemoteRuby> {
-        // Detect host first — this decides which release source to query.
         let host = match HostPlatform::current() {
             Ok(h) => h,
             Err(e) => {
@@ -67,23 +94,24 @@ impl Config {
             }
         };
 
-        let ((fetch_result, url), cache_file) = if host.is_windows() {
-            (
-                fetch_rubyinstaller2_rubies(&self.cache).await,
-                "rubyinstaller2.json",
-            )
-        } else {
-            (
-                fetch_available_rubies(&self.cache).await,
-                "available_rubies.json",
-            )
-        };
+        let (cache_file, url) = cache_target_for(&host);
 
-        let release = match fetch_result {
-            Ok(release) => release,
-            Err(e) => {
-                warn!("Could not fetch available Ruby versions: {}", e);
-                stale_cache_fallback(&self.cache, cache_file, &url)
+        let release = if self.offline {
+            debug!("Offline mode: reading available Ruby versions from cache only.");
+            stale_cache_fallback(&self.cache, cache_file, &url)
+        } else {
+            let fetch_result = if host.is_windows() {
+                fetch_rubyinstaller2_rubies(&self.cache).await.0
+            } else {
+                fetch_available_rubies(&self.cache).await.0
+            };
+
+            match fetch_result {
+                Ok(release) => release,
+                Err(e) => {
+                    warn!("Could not fetch available Ruby versions: {}", e);
+                    stale_cache_fallback(&self.cache, cache_file, &url)
+                }
             }
         };
 
@@ -107,10 +135,23 @@ impl Config {
 
         rubies
     }
-}
 
-fn cache_key_for(url: &str, cache_file: &str) -> String {
-    rv_cache::cache_digest(format!("{}-{}", url, cache_file))
+    /// Returns true if a cached list of remotely available Ruby versions exists
+    /// on disk for the current platform. Used to decide whether offline mode
+    /// can satisfy a request without falling back to network access.
+    pub fn has_cached_remote_ruby_list(&self) -> bool {
+        let host = match HostPlatform::current() {
+            Ok(h) => h,
+            Err(_) => return false,
+        };
+
+        let (cache_file, url) = cache_target_for(&host);
+        let cache_key = cache_key_for(&url, cache_file);
+        let cache_entry = self
+            .cache
+            .entry(rv_cache::CacheBucket::Ruby, "releases", cache_key);
+        cache_entry.path().is_file()
+    }
 }
 
 fn url_for(env_var: &str, default_url: &str) -> String {

--- a/crates/rv/src/gemserver.rs
+++ b/crates/rv/src/gemserver.rs
@@ -28,9 +28,10 @@ pub struct Gemserver {
     pub gems_to_deps: HashMap<String, HashMap<VersionPlatform, GemRelease>>,
     updater: Arc<Updater>,
     storage: Arc<dyn Storage>,
+    offline: bool,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum Error {
     #[error(transparent)]
     HttpError(#[from] http_fetcher::Error),
@@ -44,6 +45,10 @@ pub enum Error {
     CouldNotCreateCacheDir(std::io::Error),
     #[error("The url {url} unexpectedly returned an empty response")]
     EmptyResponse { url: Url },
+    #[error(
+        "Cannot fetch information for gem '{gem}' from {url} in offline mode: no cached data. Try again without --offline so rv can fetch the gem metadata."
+    )]
+    OfflineGemInfoMissing { gem: String, url: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -73,6 +78,7 @@ impl Gemserver {
             storage: Arc::new(storage),
             updater: Arc::new(updater),
             gems_to_deps: Default::default(),
+            offline: config.offline,
         })
     }
 
@@ -96,9 +102,22 @@ impl Gemserver {
     /// You probably want to call [`parse_release_from_body`] on the returned string.
     /// This function doesn't parse the response, so that the parser doesn't have to copy any strings.
     /// Whoever calls this should own the response, and then the parser will borrow &strs from the response.
+    ///
+    /// In offline mode, the cached blob is returned unmodified; if there is no
+    /// cached entry for the gem, an [`Error::OfflineGemInfoMissing`] is returned.
     pub async fn get_releases_for_gem(&self, gem: &str) -> Result<String> {
         let info_key = format!("info/{}", gem);
         let info_url = self.url.join(&info_key).expect("valid info URL");
+
+        if self.offline {
+            let blob = self.storage.read_blob(&info_key).await.map_err(|_| {
+                Error::OfflineGemInfoMissing {
+                    gem: gem.to_owned(),
+                    url: info_url.to_string(),
+                }
+            })?;
+            return Ok(String::from_utf8_lossy(&blob.content).to_string());
+        }
 
         let blob = if let Ok(blob) = self.storage.read_blob(&info_key).await {
             self.updater.update(info_url.as_str(), blob).await

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -85,9 +85,14 @@ struct Cli {
     #[arg(long, env = "RV_COLOR")]
     color: Option<ColorMode>,
 
-    /// Run rv in offline mode if possible
-    /// TODO: Hide until really apply offline mode in all parts of rv.
-    #[arg(long, hide = true, global = true)]
+    /// Run without network access.
+    ///
+    /// rv will skip checking for available Ruby versions, downloading Ruby
+    /// installations, and looking up or downloading gems. Operations that can
+    /// be satisfied from cached or already-installed artifacts continue to
+    /// work; operations that strictly require the network fail with an error
+    /// suggesting to retry without --offline.
+    #[arg(long, global = true)]
     offline: bool,
 
     #[command(flatten)]

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -27,6 +27,7 @@ use crate::commands::run::{RunArgs, run};
 use crate::commands::self_cmd::{SelfArgs, self_cmd};
 use crate::commands::shell::{ShellArgs, shell};
 use crate::commands::tool::{ToolArgs, tool};
+use crate::commands::vendor::{VendorArgs, vendor};
 
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Green.on_default().bold())
@@ -137,6 +138,13 @@ enum Commands {
         dont_delimit_trailing_values = true
     )]
     Run(RunArgs),
+    #[command(
+        about = "Package gems referenced by Gemfile.lock into vendor/cache",
+        long_about = "Download every gem listed in Gemfile.lock to the vendor/cache directory \
+                      so that `rv ci` (and `bundle install`) can install them without network \
+                      access. The destination respects `BUNDLE_CACHE_PATH` from .bundle/config."
+    )]
+    Vendor(VendorArgs),
 }
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]
@@ -203,6 +211,8 @@ pub enum Error {
     ShellError(#[from] commands::shell::Error),
     #[error(transparent)]
     ToolError(#[from] commands::tool::Error),
+    #[error(transparent)]
+    VendorError(#[from] commands::vendor::Error),
     #[error(transparent)]
     ConfigError(#[from] crate::config::Error),
 }
@@ -314,6 +324,7 @@ async fn run_cmd(global_args: &GlobalArgs, command: Commands) -> Result<()> {
         Commands::Shell(shell_args) => shell(global_args, &mut Cli::command(), shell_args)?,
         Commands::Tool(tool_args) => tool(global_args, tool_args).await?,
         Commands::Run(run_args) => run(global_args, run_args).await?,
+        Commands::Vendor(vendor_args) => vendor(global_args, vendor_args).await?,
     };
 
     Ok(())

--- a/crates/rv/tests/integration_tests/clean_install.rs
+++ b/crates/rv/tests/integration_tests/clean_install.rs
@@ -74,6 +74,35 @@ fn test_clean_install_consumes_vendor_cache() {
 }
 
 #[test]
+fn test_clean_install_cache_all_populates_vendor_cache() {
+    let mut test = RvTest::new();
+    test.create_ruby_dir("ruby-4.0.1");
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    let bundle_dir = test.current_dir().join(".bundle");
+    fs_err::create_dir_all(&bundle_dir).unwrap();
+    fs_err::write(
+        bundle_dir.join("config"),
+        "---\nBUNDLE_CACHE_ALL: true\n",
+    )
+    .unwrap();
+
+    let mock = test.mock_gem_download("test-gem-1.0.0.gem").create();
+    test.ci(&[]).assert_success();
+    mock.assert();
+
+    let vendored = test.current_dir().join("vendor/cache/test-gem-1.0.0.gem");
+    assert!(
+        vendored.exists(),
+        "Expected {} after ci with cache_all=true",
+        vendored,
+    );
+}
+
+#[test]
 fn test_clean_install_offline_uses_cached_gem() {
     let mut test = RvTest::new();
 

--- a/crates/rv/tests/integration_tests/clean_install.rs
+++ b/crates/rv/tests/integration_tests/clean_install.rs
@@ -27,6 +27,55 @@ fn test_clean_install_download_test_gem() {
 }
 
 #[test]
+fn test_clean_install_offline_missing_gem_fails() {
+    let mut test = RvTest::new();
+
+    test.create_ruby_dir("ruby-4.0.1");
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    let output = test.ci(&["--offline"]);
+
+    output.assert_failure();
+    output.assert_stderr_contains("OfflineGemMissing");
+}
+
+#[test]
+fn test_clean_install_offline_uses_cached_gem() {
+    let mut test = RvTest::new();
+
+    test.create_ruby_dir("ruby-4.0.1");
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    // Pre-populate the gem-archive cache that download_gem() reads, so the
+    // offline ci can satisfy itself from disk without HTTP.
+    let cache_dir = test.enable_cache();
+    let gem_path = test.gem_package_download_path("test-gem-1.0.0.gem");
+    let gem_url = format!("{}/{}", test.server_url(), gem_path);
+    let gem_content = fs_err::read("../rv-gem-package/tests/fixtures/test-gem-1.0.0.gem").unwrap();
+    let cache_key = rv_cache::cache_digest(gem_url.as_str());
+    let gems_dir = cache_dir.join("gem-v0").join("gems");
+    fs_err::create_dir_all(&gems_dir).unwrap();
+    fs_err::write(gems_dir.join(format!("{}.gem", cache_key)), &gem_content).unwrap();
+
+    let no_fetch_guard = test
+        .mock_request("GET", gem_path.as_str())
+        .with_status(200)
+        .expect(0)
+        .create();
+
+    let output = test.ci(&["--offline"]);
+
+    output.assert_success();
+    no_fetch_guard.assert();
+}
+
+#[test]
 fn test_clean_install_input_validation() {
     let mut test = RvTest::new();
 

--- a/crates/rv/tests/integration_tests/clean_install.rs
+++ b/crates/rv/tests/integration_tests/clean_install.rs
@@ -43,6 +43,37 @@ fn test_clean_install_offline_missing_gem_fails() {
 }
 
 #[test]
+fn test_clean_install_consumes_vendor_cache() {
+    let mut test = RvTest::new();
+    test.create_ruby_dir("ruby-4.0.1");
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    // Pre-populate vendor/cache with the Bundler-compatible filename. With this
+    // present, `rv ci` must skip both the user-cache and network paths.
+    let vendor_dir = test.current_dir().join("vendor/cache");
+    fs_err::create_dir_all(&vendor_dir).unwrap();
+    let gem_content =
+        fs_err::read("../rv-gem-package/tests/fixtures/test-gem-1.0.0.gem").unwrap();
+    fs_err::write(vendor_dir.join("test-gem-1.0.0.gem"), &gem_content).unwrap();
+
+    let no_fetch_guard = test
+        .mock_request(
+            "GET",
+            test.gem_package_download_path("test-gem-1.0.0.gem").as_str(),
+        )
+        .with_status(200)
+        .expect(0)
+        .create();
+
+    let output = test.ci(&[]);
+    output.assert_success();
+    no_fetch_guard.assert();
+}
+
+#[test]
 fn test_clean_install_offline_uses_cached_gem() {
     let mut test = RvTest::new();
 

--- a/crates/rv/tests/integration_tests/clean_install.rs
+++ b/crates/rv/tests/integration_tests/clean_install.rs
@@ -55,14 +55,14 @@ fn test_clean_install_consumes_vendor_cache() {
     // present, `rv ci` must skip both the user-cache and network paths.
     let vendor_dir = test.current_dir().join("vendor/cache");
     fs_err::create_dir_all(&vendor_dir).unwrap();
-    let gem_content =
-        fs_err::read("../rv-gem-package/tests/fixtures/test-gem-1.0.0.gem").unwrap();
+    let gem_content = fs_err::read("../rv-gem-package/tests/fixtures/test-gem-1.0.0.gem").unwrap();
     fs_err::write(vendor_dir.join("test-gem-1.0.0.gem"), &gem_content).unwrap();
 
     let no_fetch_guard = test
         .mock_request(
             "GET",
-            test.gem_package_download_path("test-gem-1.0.0.gem").as_str(),
+            test.gem_package_download_path("test-gem-1.0.0.gem")
+                .as_str(),
         )
         .with_status(200)
         .expect(0)
@@ -84,11 +84,7 @@ fn test_clean_install_cache_all_populates_vendor_cache() {
 
     let bundle_dir = test.current_dir().join(".bundle");
     fs_err::create_dir_all(&bundle_dir).unwrap();
-    fs_err::write(
-        bundle_dir.join("config"),
-        "---\nBUNDLE_CACHE_ALL: true\n",
-    )
-    .unwrap();
+    fs_err::write(bundle_dir.join("config"), "---\nBUNDLE_CACHE_ALL: true\n").unwrap();
 
     let mock = test.mock_gem_download("test-gem-1.0.0.gem").create();
     test.ci(&[]).assert_success();

--- a/crates/rv/tests/integration_tests/main.rs
+++ b/crates/rv/tests/integration_tests/main.rs
@@ -4,6 +4,7 @@ mod ruby;
 mod run;
 mod shell;
 mod tool;
+mod vendor;
 
 use crate::common::RvTest;
 use regex::Regex;

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -363,3 +363,90 @@ fn test_ruby_install_with_dev() {
         .join(format!("{}.tar.gz", cache_key));
     assert!(tarball_path.exists(), "Tarball should be cached");
 }
+
+#[test]
+fn test_ruby_install_offline_with_no_cache_fails() {
+    let mut test = RvTest::new();
+
+    let _cache_dir = test.enable_cache();
+
+    let output = test.rv(&["--offline", "ruby", "install", "3.4.5"]);
+
+    output.assert_failure();
+    output.assert_stderr_contains("OfflineArchiveMissing");
+}
+
+#[test]
+fn test_ruby_install_offline_underspecified_version_fails_without_cache() {
+    let mut test = RvTest::new();
+
+    let _cache_dir = test.enable_cache();
+
+    let output = test.rv(&["--offline", "ruby", "install", "3.4"]);
+
+    output.assert_failure();
+    output.assert_stderr_contains("OfflineRemoteRubyListUnavailable");
+}
+
+#[test]
+fn test_ruby_install_offline_uses_cached_archive() {
+    let mut test = RvTest::new();
+
+    let cache_dir = test.enable_cache();
+    let tarball_content = test.create_mock_tarball("3.4.5");
+    let download_path = test.ruby_tarball_download_path("3.4.5");
+    let cache_key = rv_cache::cache_digest(test.ruby_tarball_url("3.4.5"));
+    let tarballs_dir = cache_dir.join("ruby-v0").join("tarballs");
+    fs::create_dir_all(&tarballs_dir).unwrap();
+    let tarball_path = tarballs_dir.join(format!("{}.tar.gz", cache_key));
+    fs::write(&tarball_path, &tarball_content).unwrap();
+
+    let no_fetch_guard = test
+        .mock_request("GET", download_path.as_str())
+        .with_status(200)
+        .expect(0)
+        .create();
+
+    let output = test.rv(&["--offline", "ruby", "install", "3.4.5"]);
+
+    output.assert_success();
+    output
+        .assert_stdout_contains("Installed Ruby version 3.4.5 to /tmp/home/.local/share/rv/rubies");
+    no_fetch_guard.assert();
+}
+
+// The offline short-circuit must be exercised by a request that the
+// non-offline guards (line ~100 `is_requested_ruby_installed_in_dir`) do not
+// catch. We use a fuzzy request `3.4` while `ruby-3.4.5` is installed:
+//
+//   * with --offline: short-circuits on `current_ruby()` match, success.
+//   * without --offline: falls through to `find_matching_remote_ruby`, which
+//     attempts a release-list fetch, hits the mock server with no matching
+//     mock, and fails.
+//
+// If the offline short-circuit ever regresses to ignoring `config.offline`,
+// the without-offline case starts succeeding and the test catches it.
+#[test]
+fn test_ruby_install_offline_uses_already_installed_for_fuzzy_request() {
+    let mut test = RvTest::new();
+    let _cache_dir = test.enable_cache();
+    test.create_ruby_dir("ruby-3.4.5");
+
+    let output = test.rv(&["--offline", "ruby", "install", "3.4"]);
+    output.assert_success();
+    output.assert_stdout_contains("already installed");
+    output.assert_stdout_contains("ruby-3.4.5");
+}
+
+#[test]
+fn test_ruby_install_fuzzy_request_without_offline_does_not_short_circuit() {
+    let mut test = RvTest::new();
+    let _cache_dir = test.enable_cache();
+    test.create_ruby_dir("ruby-3.4.5");
+
+    // No --offline, no mocks: the fuzzy resolution must reach the network
+    // (and fail). If the offline short-circuit fires unconditionally, this
+    // would incorrectly succeed.
+    let output = test.rv(&["ruby", "install", "3.4"]);
+    output.assert_failure();
+}

--- a/crates/rv/tests/integration_tests/ruby/list_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/list_test.rs
@@ -425,6 +425,38 @@ fn test_ruby_list_windows_platform_finds_rubies() {
     );
 }
 
+#[test]
+fn test_ruby_list_offline_with_no_cache_fails() {
+    let mut test = RvTest::new();
+
+    let _cache_dir = test.enable_cache();
+
+    // No mocks: any HTTP fetch would fail. Without a cached release list, the
+    // command must fail loudly rather than silently skip the remote section.
+    let output = test.ruby_list(&["--offline"]);
+
+    output.assert_failure();
+    output.assert_stderr_contains("OfflineRemoteRubyListUnavailable");
+}
+
+#[test]
+fn test_ruby_list_offline_installed_only_works_without_cache() {
+    let test = RvTest::new();
+
+    test.create_ruby_dir("ruby-3.4.1");
+
+    // `--installed-only` skips the remote release list entirely, so offline
+    // mode is fine even without a populated cache.
+    let output = test.ruby_list(&["--offline", "--installed-only", "--format", "json"]);
+
+    output.assert_success();
+    let stdout = output.normalized_stdout();
+    assert!(
+        stdout.contains("ruby-3.4.1"),
+        "Expected installed ruby in output, got: {stdout}",
+    );
+}
+
 /// Verifies that each non-Windows platform sees only its own rubies when
 /// the release contains assets for all platforms. Windows uses a different
 /// fetch path (RubyInstaller2) and is tested separately.

--- a/crates/rv/tests/integration_tests/tool/install_test.rs
+++ b/crates/rv/tests/integration_tests/tool/install_test.rs
@@ -190,6 +190,77 @@ fn test_tool_install_writes_ruby_version_file() {
 }
 
 #[test]
+fn test_tool_install_offline_with_no_cache_fails() {
+    let test = RvTest::new();
+
+    test.create_ruby_dir("ruby-4.0.0");
+
+    let output = test.rv(&[
+        "--offline",
+        "tool",
+        "install",
+        "--gem-server",
+        &test.gemserver_url(),
+        "indirect",
+    ]);
+
+    output.assert_failure();
+    output.assert_stderr_contains("OfflineGemInfoMissing");
+}
+
+#[test]
+fn test_tool_install_offline_uses_cached_metadata_and_gem() {
+    let mut test = RvTest::new();
+
+    test.create_ruby_dir("ruby-4.0.0");
+
+    // Pre-populate the compact-index blob for `indirect` and the gem archive
+    // download cache, so offline tool-install can satisfy itself from disk.
+    let cache_dir = test.enable_cache();
+
+    let info_content = fs::read("tests/fixtures/info-indirect-gem").unwrap();
+    let compact_index_dir = cache_dir
+        .join("gemdeps-v0")
+        .join("compact_index")
+        .join("info");
+    fs_err::create_dir_all(&compact_index_dir).unwrap();
+    fs_err::write(compact_index_dir.join("indirect"), &info_content).unwrap();
+
+    let gem_path = test.gem_package_download_path("indirect-1.2.0.gem");
+    let gem_url = format!("{}/{}", test.server_url(), gem_path);
+    let gem_content = fs_err::read("../rv-gem-package/tests/fixtures/indirect-1.2.0.gem").unwrap();
+    let cache_key = rv_cache::cache_digest(gem_url.as_str());
+    let gems_dir = cache_dir.join("gem-v0").join("gems");
+    fs_err::create_dir_all(&gems_dir).unwrap();
+    fs_err::write(gems_dir.join(format!("{}.gem", cache_key)), &gem_content).unwrap();
+
+    // Trip-wires: any HTTP fetch would match one of these and fail expect(0).
+    let no_info_fetch = test
+        .mock_request("GET", "/info/indirect")
+        .with_status(200)
+        .expect(0)
+        .create();
+    let no_gem_fetch = test
+        .mock_request("GET", gem_path.as_str())
+        .with_status(200)
+        .expect(0)
+        .create();
+
+    let output = test.rv(&[
+        "--offline",
+        "tool",
+        "install",
+        "--gem-server",
+        &test.gemserver_url(),
+        "indirect",
+    ]);
+
+    output.assert_success();
+    no_info_fetch.assert();
+    no_gem_fetch.assert();
+}
+
+#[test]
 fn test_tool_install_package_data_tar_gz_with_trailing_garbage() {
     let mut test = RvTest::new();
 

--- a/crates/rv/tests/integration_tests/vendor.rs
+++ b/crates/rv/tests/integration_tests/vendor.rs
@@ -1,0 +1,96 @@
+use crate::common::{RvOutput, RvTest};
+
+impl RvTest {
+    pub fn vendor(&mut self, args: &[&str]) -> RvOutput {
+        self.rv(&[&["vendor"], args].concat())
+    }
+}
+
+#[test]
+fn test_vendor_downloads_gems_with_bundler_filenames() {
+    let mut test = RvTest::new();
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    let mock = test.mock_gem_download("test-gem-1.0.0.gem").create();
+
+    let output = test.vendor(&[]);
+
+    mock.assert();
+    output.assert_success();
+    output.assert_stdout_contains("Vendored");
+
+    let vendored = test.current_dir().join("vendor/cache/test-gem-1.0.0.gem");
+    assert!(
+        vendored.exists(),
+        "Expected gem at {} after vendor",
+        vendored,
+    );
+}
+
+#[test]
+fn test_vendor_is_idempotent() {
+    let mut test = RvTest::new();
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    // First run downloads exactly once.
+    let mock = test.mock_gem_download("test-gem-1.0.0.gem").expect(1).create();
+
+    test.vendor(&[]).assert_success();
+
+    // Second run must not hit the network.
+    let second = test.vendor(&[]);
+    second.assert_success();
+    second.assert_stdout_contains("1 already present");
+
+    mock.assert();
+}
+
+#[test]
+fn test_vendor_offline_is_rejected() {
+    let test = RvTest::new();
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    let output = test.rv(&["--offline", "vendor"]);
+    output.assert_failure();
+    output.assert_stderr_contains("OfflineNotSupported");
+}
+
+#[test]
+fn test_vendor_honors_bundle_cache_path() {
+    let mut test = RvTest::new();
+
+    test.use_gemfile("../rv-lockfile/tests/inputs/Gemfile.testsource");
+    test.use_lockfile("../rv-lockfile/tests/inputs/Gemfile.testsource.lock");
+    test.replace_source("http://gems.example.com", &test.server_url());
+
+    let bundle_dir = test.current_dir().join(".bundle");
+    std::fs::create_dir_all(&bundle_dir).unwrap();
+    std::fs::write(
+        bundle_dir.join("config"),
+        "---\nBUNDLE_CACHE_PATH: my/cache\n",
+    )
+    .unwrap();
+
+    let mock = test.mock_gem_download("test-gem-1.0.0.gem").create();
+    test.vendor(&[]).assert_success();
+    mock.assert();
+
+    let vendored = test.current_dir().join("my/cache/test-gem-1.0.0.gem");
+    assert!(vendored.exists(), "Expected gem at custom cache path");
+    assert!(
+        !test
+            .current_dir()
+            .join("vendor/cache/test-gem-1.0.0.gem")
+            .exists(),
+        "Default vendor/cache should be untouched when BUNDLE_CACHE_PATH is set",
+    );
+}

--- a/crates/rv/tests/integration_tests/vendor.rs
+++ b/crates/rv/tests/integration_tests/vendor.rs
@@ -39,7 +39,10 @@ fn test_vendor_is_idempotent() {
     test.replace_source("http://gems.example.com", &test.server_url());
 
     // First run downloads exactly once.
-    let mock = test.mock_gem_download("test-gem-1.0.0.gem").expect(1).create();
+    let mock = test
+        .mock_gem_download("test-gem-1.0.0.gem")
+        .expect(1)
+        .create();
 
     test.vendor(&[]).assert_success();
 


### PR DESCRIPTION
## Summary

Adds offline support to `rv` in two layers: a `--offline` flag that suppresses network calls and uses cached/installed artifacts, and a Bundler-compatible `rv vendor` workflow that pre-downloads gems into `vendor/cache/` so installs work without network at all.

The combination delivers the canonical Ruby "offline install" workflow:

```sh
rv vendor           # one-time, populates vendor/cache/ from Gemfile.lock
rv ci --offline     # installs without touching the network
```

## What's covered

1. **Global `--offline` flag.** Threaded through `Config`; each network entry point checks it and either uses cached/installed artifacts or fails with a clear error suggesting to retry without `--offline`.
2. **Network entry points gated.**
   - Ruby version discovery / `ruby list` — reads cached release JSON only; fails loudly if no cache.
   - `ruby install` — short-circuits with "already installed" when a matching ruby is present; otherwise requires a cached archive.
   - `gemserver` — returns cached compact-index blobs only.
   - `clean_install` `download_gem` — returns cached gem only.
   - Self-update — direct offline guard plus existing `update_mode = "none"` rewrite.
3. **`rv vendor` command.** Walks `Gemfile.lock`, downloads every rubygems-sourced `.gem` to `vendor/cache/` with Bundler-compatible filenames (`<gem>-<version>[-<platform>].gem`). Idempotent. Honors `BUNDLE_CACHE_PATH`. Validates lockfile checksums.
4. **`rv ci` consumes `vendor/cache/`.** When a Bundler-style `vendor/cache/<gem>-<v>.gem` is present, it's used ahead of the user cache and network — same precedence Bundler uses. Lookup order: `vendor/cache/` → user cache → network (without `--offline`) / fail with `OfflineGemMissing` (with `--offline`).
5. **`BUNDLE_CACHE_ALL` auto-population.** When the Bundler setting is `true`, `rv ci` writes downloaded gems to `vendor/cache/` as a side effect (Bundler-compatible).

Out of scope (deferred):
- Git/path sources in `rv vendor`.
- `rv ruby install dev --offline` test coverage (the code path is gated by `OfflineDevReleaseLookup`).

## Test plan

15 new integration tests under `crates/rv/tests/integration_tests/`:

**`--offline` failure paths** — each network entry point asserts the offline error variant fires when nothing is cached:
- `test_ruby_install_offline_with_no_cache_fails`
- `test_ruby_install_offline_underspecified_version_fails_without_cache`
- `test_ruby_list_offline_with_no_cache_fails`
- `test_clean_install_offline_missing_gem_fails`
- `test_tool_install_offline_with_no_cache_fails`

**`--offline` success paths** — pre-populate caches and assert success with `expect(0)` trip-wire mocks that fail the test if any HTTP request leaks through:
- `test_ruby_install_offline_uses_cached_archive`
- `test_ruby_list_offline_installed_only_works_without_cache`
- `test_clean_install_offline_uses_cached_gem`
- `test_tool_install_offline_uses_cached_metadata_and_gem`

**Boundary / regression guards:**
- `test_ruby_install_offline_uses_already_installed_for_fuzzy_request` — proves the short-circuit fires
- `test_ruby_install_fuzzy_request_without_offline_does_not_short_circuit` — proves it doesn't fire without `--offline`

**Vendor workflow:**
- `test_vendor_downloads_gems_with_bundler_filenames`
- `test_vendor_is_idempotent`
- `test_vendor_offline_is_rejected`
- `test_vendor_honors_bundle_cache_path`
- `test_clean_install_consumes_vendor_cache` — proves `rv ci` reads `vendor/cache/` and skips both user cache and network
- `test_clean_install_cache_all_populates_vendor_cache` — proves `BUNDLE_CACHE_ALL` side-effect works

Plus 4 new unit tests for the Bundler config readers (`cache_all`, `cache_path` defaults and overrides). All 261 tests in `cargo test -p rv` pass; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

Fixes #444
