### PR TITLE
fix: print a verbose error when ruby-version file is empty

### DIFF
--- a/crates/rv/src/config.rs
+++ b/crates/rv/src/config.rs
@@ -363,10 +363,18 @@ fn find_directory_ruby(dir: &Utf8PathBuf) -> Result<Option<(RubyRequest, Source)
     let ruby_version = dir.join(".ruby-version");
     if ruby_version.exists() {
         let ruby_version_string = std::fs::read_to_string(&ruby_version)?;
-        return Ok(Some((
-            ruby_version_string.parse()?,
-            Source::DotRubyVersion(ruby_version),
-        )));
+        match ruby_version_string.parse::<RubyRequest>() {
+            Ok(req) => {
+                return Ok(Some((req, Source::DotRubyVersion(ruby_version))));
+            }
+            Err(RequestError::EmptyInput) => {
+                error!(
+                    "The file {} is empty. Please provide a ruby version or remove the file.",
+                    ruby_version
+                );
+            }
+            Err(err) => return Err(err.into()),
+        };
     }
 
     let tool_versions = dir.join(".tool-versions");
@@ -377,10 +385,13 @@ fn find_directory_ruby(dir: &Utf8PathBuf) -> Result<Option<(RubyRequest, Source)
             .find_map(|l| l.trim_start().strip_prefix("ruby "));
 
         if let Some(version) = tool_version {
-            return Ok(Some((
-                version.parse()?,
-                Source::DotToolVersions(tool_versions),
-            )));
+            match version.parse::<RubyRequest>() {
+                Ok(req) => return Ok(Some((req, Source::DotToolVersions(tool_versions)))),
+                Err(RequestError::EmptyInput) => {
+                    error!("The entry for ruby in {} is empty.", tool_versions);
+                }
+                Err(err) => return Err(err.into()),
+            }
         }
     }
 

--- a/crates/rv/tests/integration_tests/ruby/find_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/find_test.rs
@@ -71,10 +71,10 @@ fn test_ruby_find_dot_ruby_version_empty() {
     test.create_ruby_dir("ruby-3.3.5");
     test.create_ruby_dir("ruby-3.4.5");
     let find = test.ruby_find(&[]);
-    find.assert_failure();
-    assert_eq!(
-        find.normalized_stderr(),
-        "Error: RubyError(FindError(ConfigError(RequestError(EmptyInput))))\n"
+    find.assert_success();
+    assert!(
+        find.normalized_stderr()
+            .contains("Please provide a ruby version or remove the file."),
     );
 }
 


### PR DESCRIPTION
It catches the EmptyInput error from RubyRequest parser and show a more detailed message. The problem with this solution is that the message could be annoying, it appears twice and in every command inside the folder of the empty ruby-version file because of the execution of shell commands.

Example:
<img width="1328" height="318" alt="image" src="https://github.com/user-attachments/assets/d5a40bd8-7b34-4c44-abd6-baa1ca3bea7a" />

try to fix #703 