### PR TITLE
Gitlab smoke test should now be passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
           - diaspora
           - discourse
           - fastlane
-          # - gitlab  # Disabled until https://gitlab.com/gitlab-org/gitlab/-/issues/522903 is resolved
+          - gitlab
           - homebrew
           - huginn
           - llhttp-ffi


### PR DESCRIPTION
Because the related issue has been closed.