### PR TITLE
Provide long help via `rv help`, remove per-command help subcommands

### DIFF
--- a/crates/rv/src/commands/cache.rs
+++ b/crates/rv/src/commands/cache.rs
@@ -7,6 +7,7 @@ use rv_cache::CleanReporter;
 use crate::{GlobalArgs, config::Config};
 
 #[derive(Args)]
+#[command(disable_help_subcommand = true)]
 pub struct CacheCommandArgs {
     #[command(subcommand)]
     pub command: CacheCommand,

--- a/crates/rv/src/commands/ruby.rs
+++ b/crates/rv/src/commands/ruby.rs
@@ -17,6 +17,7 @@ pub mod run;
 pub mod uninstall;
 
 #[derive(Args)]
+#[command(disable_help_subcommand = true)]
 pub struct RubyArgs {
     #[command(subcommand)]
     pub command: RubyCommand,

--- a/crates/rv/src/commands/self_cmd.rs
+++ b/crates/rv/src/commands/self_cmd.rs
@@ -16,6 +16,7 @@ pub enum Error {
 type Result<T> = miette::Result<T, Error>;
 
 #[derive(Args)]
+#[command(disable_help_subcommand = true)]
 pub struct SelfArgs {
     #[command(subcommand)]
     pub command: SelfCommand,

--- a/crates/rv/src/commands/shell.rs
+++ b/crates/rv/src/commands/shell.rs
@@ -12,6 +12,7 @@ use crate::commands::shell::init::init;
 
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
+#[command(disable_help_subcommand = true)]
 #[group(required = true, multiple = false)]
 pub struct ShellArgs {
     #[arg(value_enum)]

--- a/crates/rv/src/commands/tool.rs
+++ b/crates/rv/src/commands/tool.rs
@@ -10,6 +10,7 @@ use clap::{Args, Subcommand};
 use crate::{GlobalArgs, commands::tool, output_format::OutputFormat};
 
 #[derive(Args)]
+#[command(disable_help_subcommand = true)]
 pub struct ToolArgs {
     #[command(subcommand)]
     pub command: ToolCommand,

--- a/crates/rv/tests/integration_tests/main.rs
+++ b/crates/rv/tests/integration_tests/main.rs
@@ -35,3 +35,71 @@ fn test_global_flags() {
         "--gemfile should not be a global flag"
     );
 }
+
+// The `help` subcommand exists only at the top level: `rv help [NAME]` prints the
+// help of the targeted command. The per-command `rv NAME help` forms are removed
+// because having many ways to ask for help is confusing (see issue #431).
+
+#[test]
+fn test_help_subcommand_shows_long_help() {
+    // The `help` subcommand renders *long* help, whereas `-h`/`--help` render short help.
+    // Long help expands enum variant descriptions; short help only lists the bare values.
+    let test = RvTest::new();
+
+    let long = test.rv(&["help"]);
+    long.assert_success();
+    long.assert_stdout_contains("Use color output if the output supports it");
+
+    let short = test.rv(&["-h"]);
+    short.assert_success();
+    assert!(
+        !short
+            .stdout()
+            .contains("Use color output if the output supports it"),
+        "short help (`-h`) should not expand enum variant descriptions"
+    );
+}
+
+#[test]
+fn test_help_subcommand_shows_nested_command_help() {
+    let test = RvTest::new();
+    let result = test.rv(&["help", "ruby", "pin"]);
+    result.assert_success();
+    result.assert_stdout_contains("Show or set the Ruby version for the current project");
+    result.assert_stdout_contains("Usage: rv ruby pin");
+}
+
+#[test]
+fn test_help_subcommand_removed_from_command_groups() {
+    let test = RvTest::new();
+    for group in ["ruby", "tool", "cache", "self"] {
+        let result = test.rv(&[group, "help"]);
+        result.assert_failure();
+        result.assert_stderr_contains("unrecognized subcommand 'help'");
+    }
+}
+
+#[test]
+fn test_help_subcommand_removed_from_shell() {
+    // `rv shell` takes a positional shell name (e.g. `zsh`), so `help` is rejected as
+    // an invalid value rather than an unrecognized subcommand. Either way, the `help`
+    // subcommand is gone and the command fails instead of printing help.
+    let test = RvTest::new();
+    let result = test.rv(&["shell", "help"]);
+    result.assert_failure();
+}
+
+#[test]
+fn test_help_not_advertised_as_command_group_subcommand() {
+    let test = RvTest::new();
+    for group in ["ruby", "tool", "cache", "self"] {
+        let result = test.rv(&[group, "-h"]);
+        result.assert_success();
+        assert!(
+            !result
+                .stdout()
+                .contains("Print this message or the help of the given subcommand(s)"),
+            "`help` should not be listed as a subcommand of `rv {group}`"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #431.

## What this does

Help is now requested in two consistent ways:

- `rv … -h` / `rv … --help` show **short** help (unchanged)
- `rv help [NAME]` shows **long** help for the targeted command

The per-command `rv NAME help` forms (e.g. `rv ruby help pin`) are removed by disabling the auto-generated `help` subcommand on each command group (`ruby`, `tool`, `cache`, `self`, `shell`), so there is a single way to ask for full help. The top-level `help` subcommand is preserved, so `rv help ruby pin` still works.

This addresses the two open checkboxes in #431:

- [x] `rv help [NAME]` shows long help
- [x] `rv NAME help` removed

### Before / after

| Invocation | Before | After |
|---|---|---|
| `rv … -h` / `--help` | short | short (unchanged) |
| `rv help [NAME]` | long | long (now covered by a regression test) |
| `rv ruby help pin` | printed help | removed → errors |
| `rv ruby -h` command list | listed `help` | no longer lists `help` |
| `rv help ruby pin` (top level) | worked | still works |

## Implementation

Five one-line additions of `#[command(disable_help_subcommand = true)]` to the command-group arg structs. clap's `help` subcommand renders long help (`write_long_help`) while `-h`/`--help` are mapped to `HelpShort`, so the long-vs-short routing already follows from keeping the top-level help subcommand and removing the nested ones.

## Tests

`crates/rv/tests/integration_tests/main.rs`:

- `test_help_subcommand_shows_long_help` — `rv help` expands enum descriptions; `rv -h` does not
- `test_help_subcommand_shows_nested_command_help` — `rv help ruby pin` still prints the command's help
- `test_help_subcommand_removed_from_command_groups` — `rv {ruby,tool,cache,self} help` → `unrecognized subcommand 'help'`
- `test_help_subcommand_removed_from_shell` — `rv shell help` fails
- `test_help_not_advertised_as_command_group_subcommand` — `help` no longer appears in the `-h` command listing for `ruby`/`tool`/`cache`/`self`

Each behavior-changing test was confirmed to fail against the pre-change source. Full suite (`cargo nextest run -p rv`), `cargo fmt --all -- --check`, and `cargo clippy -p rv --all-targets` all pass.

## Notes for reviewers (out of scope / open question)

1. **Leaf positional swallows `help`.** On commands whose leaf takes a positional, `help` is consumed as a value rather than rejected: `rv ruby pin help` pins the version to the literal `"help"`, and `rv shell help` errors as `invalid value 'help' for '[SHELL]'` rather than `unrecognized subcommand 'help'`. These aren't help subcommands, so they're untouched by this change. Happy to address separately if you'd like them to error explicitly.
2. **No `long_about` prose authored.** This PR makes `rv help [NAME]` *route* to long help, but long help only differs visibly where an arg carries rich metadata (e.g. `--color`'s enum descriptions). If you want genuinely richer per-command long help, that's a larger, separate effort I left out here. Let me know if it should be part of this issue.