### PR TITLE
Metadata: read created_at as a field

### DIFF
--- a/crates/rv/src/gemserver.rs
+++ b/crates/rv/src/gemserver.rs
@@ -519,6 +519,9 @@ mod tests {
     fn test_unknown_and_created_at_metadata() {
         let input = "1.0.0 |checksum:505c6770a5ec896244d31d7eac08663696d22140493ddb820f66d12670b669d2,created_at:2011-08-15T18:41:56Z,unknown_key_to_ignore:foo";
         let actual = GemRelease::parse(input).unwrap();
-        assert_eq!(actual.metadata.created_at, Some("2011-08-15T18:41:56Z".to_string()));
+        assert_eq!(
+          actual.metadata.created_at,
+          Some("2011-08-15T18:41:56Z".to_string())
+        );
     }
 }

--- a/crates/rv/src/gemserver.rs
+++ b/crates/rv/src/gemserver.rs
@@ -520,8 +520,8 @@ mod tests {
         let input = "1.0.0 |checksum:505c6770a5ec896244d31d7eac08663696d22140493ddb820f66d12670b669d2,created_at:2011-08-15T18:41:56Z,unknown_key_to_ignore:foo";
         let actual = GemRelease::parse(input).unwrap();
         assert_eq!(
-          actual.metadata.created_at,
-          Some("2011-08-15T18:41:56Z".to_string())
+            actual.metadata.created_at,
+            Some("2011-08-15T18:41:56Z".to_string())
         );
     }
 }

--- a/crates/rv/src/gemserver.rs
+++ b/crates/rv/src/gemserver.rs
@@ -369,11 +369,11 @@ fn parse_metadata(metadata: &str) -> ParseResult<Metadata> {
             "published_at" => {
                 //Unused for now
             }
+            "created_at" => {
+                out.created_at = Some(v.to_owned());
+            }
             _ => {
-                return Err(GemReleaseParse::UnknownMetadataKey {
-                    key: k.to_owned(),
-                    metadata: md_str.to_owned(),
-                });
+                // Ignore other fields in the future
             }
         }
     }
@@ -404,6 +404,7 @@ pub struct Metadata {
     pub checksum: Vec<u8>,
     pub ruby: Requirement,
     pub rubygems: Requirement,
+    pub created_at: Option<String>,
 }
 
 impl Default for Metadata {
@@ -416,6 +417,7 @@ impl Default for Metadata {
             rubygems: Requirement {
                 constraints: vec![],
             },
+            created_at: None,
         }
     }
 }
@@ -426,6 +428,7 @@ impl std::fmt::Debug for Metadata {
             .field("checksum", &hex::encode(&self.checksum))
             .field("ruby", &self.ruby)
             .field("rubygems", &self.rubygems)
+            .field("created_at", &self.created_at)
             .finish()
     }
 }
@@ -510,5 +513,12 @@ mod tests {
                 .to_string(),
             expected_release
         );
+    }
+
+    #[test]
+    fn test_unknown_and_created_at_metadata() {
+        let input = "1.0.0 |checksum:505c6770a5ec896244d31d7eac08663696d22140493ddb820f66d12670b669d2,created_at:2011-08-15T18:41:56Z,unknown_key_to_ignore:foo";
+        let actual = GemRelease::parse(input).unwrap();
+        assert_eq!(actual.metadata.created_at, Some("2011-08-15T18:41:56Z".to_string()));
     }
 }

--- a/crates/rv/src/snapshots/rv__gemserver__tests__body_parser.snap
+++ b/crates/rv/src/snapshots/rv__gemserver__tests__body_parser.snap
@@ -33,6 +33,7 @@ expression: actual_parsed_response
             checksum: "84fd0ee92f92088cff81d1a4bcb61306bd4b7440b8634d7ac3d1396571a2133f",
             ruby: [],
             rubygems: [],
+            created_at: None,
         },
     },
     GemRelease {
@@ -65,6 +66,7 @@ expression: actual_parsed_response
             checksum: "ac61e0356987df34dbbafb803b98f153a663d3878a31f1db7333b7cd987fd044",
             ruby: [],
             rubygems: [],
+            created_at: None,
         },
     },
 ]


### PR DESCRIPTION
Previously `created_at` would cause an `Err` due to `UnknownMetadataKey`. This change reads & exposes the `created_at` field to eliminate that Error. It also ignores all unknown fields going forward.

Fixes #715 by exposing `created_at`.