### PR TITLE
add `rv fmt` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,11 +131,6 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Install faketty
-        uses: taiki-e/install-action@8f531eaecd1898bc3da7d104ad91bee98d1b97bd # v2.79.9
-        with:
-          tool: faketty
-
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -152,14 +147,12 @@ jobs:
 
       - name: Run Windows integration tests
         if: ${{ startsWith(matrix.runs-on, 'windows') }}
-        shell: 'faketty {0}'
         run: ./win/test-integration.ps1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unix integration tests
         if: ${{ ! startsWith(matrix.runs-on, 'windows') }}
-        shell: 'faketty {0}'
         run: ./bin/test-integration
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,11 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Install faketty
+        uses: taiki-e/install-action@8f531eaecd1898bc3da7d104ad91bee98d1b97bd # v2.79.9
+        with:
+          tool: faketty
+
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -147,13 +152,14 @@ jobs:
 
       - name: Run Windows integration tests
         if: ${{ startsWith(matrix.runs-on, 'windows') }}
+        shell: faketty
         run: ./win/test-integration.ps1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unix integration tests
         if: ${{ ! startsWith(matrix.runs-on, 'windows') }}
-        shell: 'script -q -e -c "bash {0}"'
+        shell: faketty
         run: ./bin/test-integration
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,7 @@ jobs:
 
       - name: Run Unix integration tests
         if: ${{ ! startsWith(matrix.runs-on, 'windows') }}
+        shell: 'script -q -e -c "bash {0}"'
         run: ./bin/test-integration
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,14 +152,14 @@ jobs:
 
       - name: Run Windows integration tests
         if: ${{ startsWith(matrix.runs-on, 'windows') }}
-        shell: faketty
+        shell: 'faketty {0}'
         run: ./win/test-integration.ps1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unix integration tests
         if: ${{ ! startsWith(matrix.runs-on, 'windows') }}
-        shell: faketty
+        shell: 'faketty {0}'
         run: ./bin/test-integration
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -704,7 +704,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1132,7 +1132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2195,7 +2195,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2896,8 +2896,8 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt"
-version = "0.14.0"
-source = "git+https://github.com/fables-tales/rubyfmt.git?branch=trunk#8991bc906fc07dba3382d6dee1c8ba3008bd87cb"
+version = "0.14.1"
+source = "git+https://github.com/fables-tales/rubyfmt.git?branch=trunk#b63fbaa9f2ac77c84c297e88f025037120e3f077"
 dependencies = [
  "log",
  "memchr",
@@ -2937,7 +2937,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2995,7 +2995,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3601,7 +3601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3729,7 +3729,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3748,7 +3748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4469,7 +4469,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -516,6 +545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +600,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -880,6 +929,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "current_platform"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1067,18 @@ dependencies = [
  "jwalk",
  "log",
  "walkdir",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1725,7 +1797,7 @@ dependencies = [
  "console",
  "once_cell",
  "serde",
- "similar",
+ "similar 2.7.0",
  "tempfile",
 ]
 
@@ -1837,12 +1909,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1904,14 +1974,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.15"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "plain",
  "redox_syscall 0.7.3",
 ]
 
@@ -2062,7 +2141,7 @@ dependencies = [
  "regex",
  "serde_json",
  "serde_urlencoded",
- "similar",
+ "similar 2.7.0",
  "tokio",
 ]
 
@@ -2164,6 +2243,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,7 +2364,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall 0.5.13",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2309,12 +2412,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2663,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -2774,6 +2871,39 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ruby-prism"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b302f00359d0b5423a600314935ca5f994484e15da2db5345631d28c6e029d6"
+dependencies = [
+ "ruby-prism-sys",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ruby-prism-sys"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f85fd9571455bdca2b3bf0b2f543cd13ac39d5de0026a8eb2deb94ffd264f00"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
+name = "rubyfmt"
+version = "0.14.0"
+source = "git+https://github.com/fables-tales/rubyfmt.git?branch=trunk#8991bc906fc07dba3382d6dee1c8ba3008bd87cb"
+dependencies = [
+ "log",
+ "memchr",
+ "ruby-prism",
+ "simplelog",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -2924,6 +3054,7 @@ dependencies = [
  "clap_complete_nushell",
  "clap_derive",
  "config",
+ "ctrlc",
  "current_platform",
  "dep-graph",
  "dircpy",
@@ -2933,6 +3064,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex",
+ "ignore",
  "indexmap",
  "indicatif",
  "indoc",
@@ -2949,6 +3081,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rexpect",
+ "rubyfmt",
  "rv-cache",
  "rv-client",
  "rv-dirs",
@@ -2966,6 +3099,7 @@ dependencies = [
  "sha2 0.11.0",
  "shell-escape",
  "shell-quote",
+ "similar 3.1.0",
  "tabled",
  "tar",
  "tempfile",
@@ -3192,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3429,6 +3563,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "similar"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,6 +3733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,6 +3827,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,7 +3855,9 @@ dependencies = [
  "deranged",
  "itoa",
  "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4114,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4127,19 +4312,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4147,9 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4160,9 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -4216,9 +4405,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,15 +418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,17 +920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
-dependencies = [
- "dispatch2",
- "nix 0.31.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "current_platform"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,18 +1047,6 @@ dependencies = [
  "jwalk",
  "log",
  "walkdir",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
 ]
 
 [[package]]
@@ -2252,21 +2220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,7 +3007,6 @@ dependencies = [
  "clap_complete_nushell",
  "clap_derive",
  "config",
- "ctrlc",
  "current_platform",
  "dep-graph",
  "dircpy",

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -2,8 +2,6 @@
 set -euo pipefail
 
 RUBY_VERSION="3.4.7"
-
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RV="cargo run --"
 
 echo "=== rv run --ruby $RUBY_VERSION ruby (install + execute) ==="

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -85,7 +85,23 @@ fi
 echo "PASS: stdin formatted on stdout"
 
 echo ""
-echo "=== rv fmt (formatting a directory) ==="
+echo "=== rv fmt . (formatting a directory in place) ==="
+mkdir fmt-test
+echo "class Hello; end" > fmt-test/hello.rb
+(
+  cd fmt-test
+  $RV fmt .
+)
+result="$(cat fmt-test/hello.rb)"
+rm -rf fmt-test
+if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
+  echo "FAIL: stdin formatted to $result"
+  exit 1
+fi
+echo "PASS: file formatted in place"
+
+echo ""
+echo "=== rv fmt (formatting PWD by default) ==="
 mkdir fmt-test
 echo "class Hello; end" > fmt-test/hello.rb
 (

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -75,6 +75,8 @@ echo "=== rv run --ruby $RUBY_VERSION ruby (re-install after uninstall) ==="
 $RV run --ruby "$RUBY_VERSION" ruby -e 'puts "re-installed"' | grep -q "re-installed"
 echo "PASS: re-installs and runs after uninstall"
 
+[ -t 1 ] || exit 0
+
 echo ""
 echo "=== rv fmt (stdin formatting to stdout) ==="
 echo "class Hello; end" | $RV fmt > hello.rb

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -69,5 +69,29 @@ echo "=== rv run --ruby $RUBY_VERSION ruby (re-install after uninstall) ==="
 $RV run --ruby "$RUBY_VERSION" ruby -e 'puts "re-installed"' | grep -q "re-installed"
 echo "PASS: re-installs and runs after uninstall"
 
+echo ""
+echo "=== rv fmt (stdin formatting to stdout) ==="
+echo "class Hello; end" | $RV fmt > hello.rb
+result="$(cat hello.rb)"
+rm hello.rb
+if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
+  echo "FAIL: stdin formatted to $result"
+  exit 1
+fi
+echo "PASS: stdin formatted on stdout"
+
+echo ""
+echo "=== rv fmt (formatting a directory) ==="
+mkdir fmt-test
+echo "class Hello; end" > fmt-test/hello.rb
+$RV fmt fmt-test
+result="$(cat fmt-test/hello.rb)"
+rm -rf fmt-test
+if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
+  echo "FAIL: stdin formatted to $result"
+  exit 1
+fi
+echo "PASS: file formatted in place"
+
 # Clean up .ruby-version left by ruby-pin.sh
 rm -f .ruby-version

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 RUBY_VERSION="3.4.7"
-cargo build --release --bin rv
+cargo build --bin rv
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-RV="$DIR/target/release/rv"
+RV="$DIR/target/debug/rv"
 
 cleanup() {
   rm -rf fmt-test
@@ -113,7 +113,7 @@ echo "class Hello; end" > fmt-test/hello.rb
 result="$(cat fmt-test/hello.rb)"
 rm -rf fmt-test
 if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
-  echo "FAIL: stdin formatted to $result"
+  echo "FAIL: fmt-test/hello.rb didn't format; was '$result'"
   exit 1
 fi
 echo "PASS: file formatted in place"
@@ -129,7 +129,7 @@ echo "class Hello; end" > fmt-test/hello.rb
 result="$(cat fmt-test/hello.rb)"
 rm -rf fmt-test
 if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
-  echo "FAIL: stdin formatted to $result"
+  echo "FAIL: fmt-test/hello.rb didn't format; was '$result'"
   exit 1
 fi
 echo "PASS: file formatted in place"

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 RUBY_VERSION="3.4.7"
-RV="cargo run --"
+cargo build --release --bin rv
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RV="$DIR/target/release/rv"
 
 cleanup() {
   rm -rf fmt-test

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -82,7 +82,10 @@ echo ""
 echo "=== rv fmt (formatting a directory) ==="
 mkdir fmt-test
 echo "class Hello; end" > fmt-test/hello.rb
-$RV fmt fmt-test
+(
+  cd fmt-test
+  $RV fmt
+)
 result="$(cat fmt-test/hello.rb)"
 rm -rf fmt-test
 if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -4,6 +4,12 @@ set -euo pipefail
 RUBY_VERSION="3.4.7"
 RV="cargo run --"
 
+cleanup() {
+  rm -rf fmt-test
+  rm -f .ruby-version
+}
+trap cleanup EXIT
+
 echo "=== rv run --ruby $RUBY_VERSION ruby (install + execute) ==="
 output=$($RV run --ruby "$RUBY_VERSION" ruby -e 'puts RUBY_DESCRIPTION')
 echo "  $output"
@@ -93,6 +99,3 @@ if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
   exit 1
 fi
 echo "PASS: file formatted in place"
-
-# Clean up .ruby-version left by ruby-pin.sh
-rm -f .ruby-version

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -99,3 +99,19 @@ if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
   exit 1
 fi
 echo "PASS: file formatted in place"
+
+echo ""
+echo "=== rv fmt (ignoring stdin while formatting a directory) ==="
+mkdir fmt-test
+echo "class Hello; end" > fmt-test/hello.rb
+(
+  cd fmt-test
+  echo "class Bad" | $RV fmt .
+)
+result="$(cat fmt-test/hello.rb)"
+rm -rf fmt-test
+if [[ "$result" != "$(printf 'class Hello\nend\n')" ]]; then
+  echo "FAIL: stdin formatted to $result"
+  exit 1
+fi
+echo "PASS: file formatted in place"

--- a/bora-nodl-doc
+++ b/bora-nodl-doc
@@ -1,1 +1,0 @@
-hello there

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -84,7 +84,6 @@ shell-quote = { version = "0.7.2", features = ["bash", "fish", "sh"], default-fe
 rubyfmt = { git = "https://github.com/fables-tales/rubyfmt.git", branch = "trunk" }
 ignore = "0.4.25"
 similar = { version = "3.1.0", features = ["bytes"] }
-ctrlc = { version = "3.5.2", features = ["termination"] }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/rv/Cargo.toml
+++ b/crates/rv/Cargo.toml
@@ -81,6 +81,10 @@ config = { version = "0.15.22", default-features = false, features = [
 kdl = { version = "6.7.0" }
 which = "8.0.2"
 shell-quote = { version = "0.7.2", features = ["bash", "fish", "sh"], default-features = false }
+rubyfmt = { git = "https://github.com/fables-tales/rubyfmt.git", branch = "trunk" }
+ignore = "0.4.25"
+similar = { version = "3.1.0", features = ["bytes"] }
+ctrlc = { version = "3.5.2", features = ["termination"] }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/rv/src/commands.rs
+++ b/crates/rv/src/commands.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod clean_install;
+pub mod fmt;
 pub mod ruby;
 pub mod run;
 pub mod self_cmd;

--- a/crates/rv/src/commands/fmt.rs
+++ b/crates/rv/src/commands/fmt.rs
@@ -1,0 +1,11 @@
+mod rubyfmt;
+
+use crate::{Error, GlobalArgs};
+use rubyfmt::CommandlineOpts;
+
+pub(crate) type FmtArgs = CommandlineOpts;
+
+pub(crate) async fn fmt(_global_args: &GlobalArgs, opts: FmtArgs) -> Result<(), Error> {
+    rubyfmt::main(opts);
+    Ok(())
+}

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -1,0 +1,449 @@
+#![deny(warnings, missing_copy_implementations)]
+
+use clap::Parser;
+use ignore::WalkBuilder;
+use ignore::gitignore::GitignoreBuilder;
+use regex::Regex;
+use rubyfmt::init_logger;
+use similar::TextDiff;
+use std::ffi::OsStr;
+use std::fs::{File, OpenOptions, read};
+use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
+use std::path::Path;
+use std::process::{Command, exit};
+use std::sync::{Arc, LazyLock, Mutex};
+
+static MAGIC_COMMENT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^#\s*rubyfmt:\s*(?P<enabled>true|false)\s*$").unwrap());
+
+/// Simple Enum to exit on errors or not
+#[derive(Debug, PartialEq, Copy, Clone)]
+enum ErrorExit {
+    NoExit,
+    Exit,
+}
+
+/// Error enum representing errors in the cli.
+#[derive(Debug)]
+enum ExecutionError {
+    // Errors seen when rubyfmt is executing
+    RubyfmtError(rubyfmt::RichFormatError, String),
+    // Errors seen when performing IO s
+    IOError(io::Error, String),
+    // Errors seen when grepping for files
+    FileSearchFailure(ignore::Error),
+}
+
+/// Rubyfmt CLI
+#[derive(Debug, Parser)]
+#[clap(name = "rubyfmt", bin_name = "rubyfmt", author, version, about, long_about = None)]
+struct CommandlineOpts {
+    /// Turn on check mode. This outputs diffs of inputs to STDOUT. Will exit non-zero when differences are detected.
+    #[clap(short, long)]
+    check: bool,
+
+    /// Turn on to ignore gitignored files. Gitignored files are not considered by rubyfmt by default.
+    #[clap(long, name = "include-gitignored")]
+    include_gitignored: bool,
+
+    /// Only format ruby files containing the magic `# rubyfmt: true` header
+    #[clap(long, name = "header-opt-in")]
+    header_opt_in: bool,
+
+    /// Do not format ruby files containing the magic `# rubyfmt: false` header
+    #[clap(long, name = "header-opt-out")]
+    header_opt_out: bool,
+
+    /// Fail on all syntax and io errors early. Warnings otherwise.
+    #[clap(long, name = "fail-fast")]
+    fail_fast: bool,
+
+    /// Write files back in place, do not write output to STDOUT.
+    #[clap(short, long, name = "in-place")]
+    in_place: bool,
+
+    /// When reading from stdin, treat the input as if it were at this path.
+    /// This allows .rubyfmtignore and .gitignore patterns to be applied to stdin input.
+    #[clap(long, name = "stdin-filepath", conflicts_with_all = ["include-paths", "in-place"])]
+    stdin_filepath: Option<String>,
+
+    /// Paths for rubyfmt to analyze. By default the output will be printed to STDOUT. See `--in-place` to write files back in-place.
+    /// Acceptable paths are:{n}
+    /// - File paths (i.e lib/foo/bar.rb){n}
+    /// - Directories (i.e. lib/foo/){n}
+    /// - Input files (i.e. @/tmp/files.txt). These files must contain one file path or directory per line
+    ///
+    /// rubyfmt will use these as input.{n}
+    #[clap(name = "include-paths")]
+    include_paths: Vec<String>,
+}
+
+/******************************************************/
+/* Error handling                                     */
+/******************************************************/
+
+fn handle_io_error(err: io::Error, source: &str, error_exit: ErrorExit) {
+    let msg = format!("Rubyfmt experienced an IO error: {}", err);
+    print_error(&msg, Some(source));
+
+    if error_exit == ErrorExit::Exit {
+        exit(rubyfmt::FormatError::IOError as i32);
+    }
+}
+
+fn handle_ignore_error(err: ignore::Error, error_exit: ErrorExit) {
+    let msg = format!("Rubyfmt experienced an error searching for files: {}", err);
+    print_error(&msg, None);
+    if error_exit == ErrorExit::Exit {
+        exit(rubyfmt::FormatError::IOError as i32);
+    }
+}
+
+fn handle_rubyfmt_error(err: rubyfmt::RichFormatError, source: &str, error_exit: ErrorExit) {
+    use rubyfmt::RichFormatError::*;
+    let exit_code = err.as_exit_code();
+    let e = || {
+        if error_exit == ErrorExit::Exit {
+            exit(exit_code);
+        }
+    };
+    match err {
+        SyntaxError => {
+            let msg = "Rubyfmt detected a syntax error in the ruby code being executed";
+            print_error(msg, Some(source));
+            e();
+        }
+        IOError(ioe) => {
+            let msg = format!("Rubyfmt experienced an IO error: {}", ioe);
+            print_error(&msg, Some(source));
+            e();
+        }
+    }
+}
+
+fn print_error(msg: &str, file_path: Option<&str>) {
+    let mut first_line: String = "Error!".to_string();
+
+    if let Some(line) = file_path {
+        first_line = format!("Error! source: {}", line);
+    }
+
+    eprintln!("{}\n{}", first_line, msg);
+}
+
+fn handle_execution_error(opts: &CommandlineOpts, err: ExecutionError) {
+    let mut exit_type = ErrorExit::NoExit;
+    // If include_paths are empty, this is operating on STDIN which should always exit
+    if opts.fail_fast || opts.include_paths.is_empty() {
+        exit_type = ErrorExit::Exit;
+    }
+
+    match err {
+        ExecutionError::RubyfmtError(e, path) => handle_rubyfmt_error(e, &path, exit_type),
+        ExecutionError::IOError(e, path) => handle_io_error(e, &path, exit_type),
+        ExecutionError::FileSearchFailure(e) => handle_ignore_error(e, exit_type),
+    }
+}
+
+/******************************************************/
+/* Rubyfmt Integration                                */
+/******************************************************/
+
+fn rubyfmt_string(
+    &CommandlineOpts {
+        header_opt_in,
+        header_opt_out,
+        ..
+    }: &CommandlineOpts,
+    buffer: &[u8],
+) -> Result<Option<Vec<u8>>, rubyfmt::RichFormatError> {
+    if header_opt_in || header_opt_out {
+        // Only look at the first 500 bytes for the magic header.
+        // This is for performance. Use lossy UTF-8 conversion since the
+        // magic comment is always ASCII.
+        let slice_size = buffer.len().min(500);
+        let slice = String::from_utf8_lossy(&buffer[..slice_size]);
+
+        let matched = MAGIC_COMMENT_REGEX
+            .captures(&slice)
+            .and_then(|c| c.name("enabled"))
+            .map(|s| s.as_str());
+
+        // If opted in to magic "# rubyfmt: true" header and true is not
+        // in the file, return early
+        if header_opt_in && Some("true") != matched {
+            return Ok(None);
+        }
+
+        // If opted in to magic "# rubyfmt: false" header and false is
+        // in the file, return early
+        if header_opt_out && Some("false") == matched {
+            return Ok(None);
+        }
+    }
+
+    rubyfmt::format_buffer(buffer).map(Some)
+}
+
+/******************************************************/
+/* Helpers                                            */
+/******************************************************/
+
+/// Check if a path should be ignored based on .gitignore and .rubyfmtignore patterns.
+/// The path should be relative to the current working directory.
+fn is_path_ignored(path: &Path, include_gitignored: bool) -> bool {
+    let cwd = std::env::current_dir().unwrap();
+    let mut builder = GitignoreBuilder::new(&cwd);
+
+    if !include_gitignored {
+        builder.add(".gitignore");
+    }
+    builder.add(".rubyfmtignore");
+
+    if let Ok(gitignore) = builder.build() {
+        let is_dir = path.is_dir();
+        gitignore
+            .matched_path_or_any_parents(path, is_dir)
+            .is_ignore()
+    } else {
+        false
+    }
+}
+
+fn file_walker_builder(include_paths: Vec<&String>, include_gitignored: bool) -> WalkBuilder {
+    // WalkBuilder does not have an API for adding multiple inputs.
+    // Must pass the first input to the constructor, and the tail afterwards.
+    // Safe to unwrap here.
+    let (include_head, include_tail) = include_paths.split_first().unwrap();
+    let mut builder = WalkBuilder::new(include_head);
+
+    for path in include_tail {
+        builder.add(path);
+    }
+
+    builder.git_ignore(!include_gitignored);
+    builder.add_custom_ignore_filename(".rubyfmtignore");
+    builder
+}
+
+// Parse command line arguments. Expand any input files.
+fn get_command_line_options() -> CommandlineOpts {
+    let opts = CommandlineOpts::parse();
+
+    let mut expanded_paths: Vec<String> = Vec::new();
+
+    for path in opts.include_paths {
+        // Expand input files
+        if let Some(file_name) = path.strip_prefix('@') {
+            match File::open(file_name) {
+                Ok(file) => {
+                    let buf = BufReader::new(file);
+                    expanded_paths.extend(buf.lines().map(|l| l.expect("Could not parse line")));
+                }
+                Err(e) => handle_io_error(e, &path, ErrorExit::Exit),
+            }
+        } else {
+            expanded_paths.push(path);
+        }
+    }
+
+    CommandlineOpts {
+        include_paths: expanded_paths,
+        ..opts
+    }
+}
+
+fn iterate_input_files(opts: &CommandlineOpts, f: InputFunc) {
+    if opts.include_paths.is_empty() {
+        // If not include paths are present, assume user is passing via STDIN
+        let mut buffer = Vec::new();
+
+        if io::stdin().is_terminal() {
+            // Call executable with `--help` args to print help statement
+            let mut command = Command::new(std::env::current_exe().unwrap());
+            command.arg("--help");
+            command.spawn().unwrap().wait().unwrap();
+            return;
+        }
+
+        io::stdin()
+            .read_to_end(&mut buffer)
+            .expect("reading from stdin to not fail");
+
+        let path = if let Some(stdin_filepath) = &opts.stdin_filepath {
+            let path = Path::new(stdin_filepath);
+            if is_path_ignored(path, opts.include_gitignored) {
+                // Print unchanged output for ignored files unless we're in check mode
+                if !opts.check {
+                    puts_stdout(&buffer);
+                }
+                return;
+            }
+            path
+        } else {
+            Path::new("stdin")
+        };
+
+        f((path, &buffer))
+    } else {
+        let mut file_paths = Vec::new();
+        let mut dir_paths = Vec::new();
+        for path in &opts.include_paths {
+            if Path::new(&path).is_file() {
+                file_paths.push(path)
+            } else {
+                dir_paths.push(path)
+            }
+        }
+
+        if !file_paths.is_empty() {
+            for result in file_walker_builder(file_paths, opts.include_gitignored).build() {
+                match result {
+                    Ok(pp) => {
+                        let file_path = pp.path();
+                        match read(file_path) {
+                            Ok(buffer) => f((file_path, &buffer)),
+                            Err(e) => handle_execution_error(
+                                opts,
+                                ExecutionError::IOError(e, file_path.display().to_string()),
+                            ),
+                        }
+                    }
+                    Err(e) => handle_execution_error(opts, ExecutionError::FileSearchFailure(e)),
+                }
+            }
+        }
+
+        if !dir_paths.is_empty() {
+            for result in file_walker_builder(dir_paths, opts.include_gitignored).build() {
+                match result {
+                    Ok(pp) => {
+                        let file_path = pp.path();
+
+                        if file_path.is_file()
+                            && file_path.extension().and_then(OsStr::to_str) == Some("rb")
+                        {
+                            match read(file_path) {
+                                Ok(buffer) => f((file_path, &buffer)),
+                                Err(e) => handle_execution_error(
+                                    opts,
+                                    ExecutionError::IOError(e, file_path.display().to_string()),
+                                ),
+                            }
+                        }
+                    }
+                    Err(e) => handle_execution_error(opts, ExecutionError::FileSearchFailure(e)),
+                }
+            }
+        }
+    }
+}
+
+type InputFunc<'a> = &'a dyn Fn((&Path, &[u8]));
+type FormattingFunc<'a> = &'a dyn Fn((&Path, &[u8], Option<Vec<u8>>));
+
+fn iterate_formatted(opts: &CommandlineOpts, f: FormattingFunc) {
+    iterate_input_files(
+        opts,
+        &|(file_path, before)| match rubyfmt_string(opts, before) {
+            Ok(r) => f((file_path, before, r)),
+            Err(e) => handle_execution_error(
+                opts,
+                ExecutionError::RubyfmtError(e, file_path.display().to_string()),
+            ),
+        },
+    );
+}
+
+fn puts_stdout(input: &[u8]) {
+    io::stdout()
+        .write_all(input)
+        .expect("Could not write to stdout");
+    io::stdout().flush().expect("flush works");
+}
+
+fn main() {
+    ctrlc::set_handler(move || {
+        eprintln!("`rubyfmt` process was terminated. Exiting...");
+        exit(1);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let opts = get_command_line_options();
+    init_logger();
+
+    match opts {
+        CommandlineOpts { check: true, .. } => {
+            let text_diffs: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+            let errors_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+
+            iterate_input_files(
+                &opts,
+                &|(file_path, before)| match rubyfmt_string(&opts, before) {
+                    Ok(None) => {}
+                    Ok(Some(fmtted)) => {
+                        let diff = TextDiff::from_lines(before, &fmtted);
+                        let path_string = file_path.to_str().unwrap();
+                        text_diffs.lock().unwrap().push(format!(
+                            "{}",
+                            diff.unified_diff().header(path_string, path_string)
+                        ));
+                    }
+                    Err(e) => {
+                        handle_rubyfmt_error(
+                            e,
+                            &file_path.display().to_string(),
+                            ErrorExit::NoExit,
+                        );
+                        *errors_count.lock().unwrap() += 1;
+                    }
+                },
+            );
+
+            let all_diffs = text_diffs.lock().unwrap();
+
+            let mut diffs_reported = 0;
+
+            for diff in all_diffs.iter() {
+                if !diff.is_empty() {
+                    puts_stdout(diff.as_bytes());
+                    diffs_reported += 1
+                }
+            }
+            let errors = *errors_count.lock().unwrap();
+            if errors > 0 {
+                exit(rubyfmt::FormatError::SyntaxError as i32);
+            } else if diffs_reported > 0 {
+                exit(rubyfmt::FormatError::DiffDetected as i32);
+            } else {
+                exit(0)
+            }
+        }
+
+        CommandlineOpts { in_place: true, .. } => {
+            iterate_formatted(&opts, &|(file_path, before, after)| match after {
+                Some(fmtted) if fmtted.ne(before) => {
+                    let file_write = OpenOptions::new()
+                        .write(true)
+                        .truncate(true)
+                        .open(file_path)
+                        .and_then(|mut file| file.write_all(&fmtted));
+
+                    match file_write {
+                        Ok(_) => {}
+                        Err(e) => handle_execution_error(
+                            &opts,
+                            ExecutionError::IOError(e, file_path.display().to_string()),
+                        ),
+                    }
+                }
+                _ => {}
+            })
+        }
+
+        _ => iterate_formatted(&opts, &|(_, before, after)| match after {
+            Some(fmtted) => puts_stdout(&fmtted),
+            None => puts_stdout(before),
+        }),
+    }
+}

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -25,7 +25,7 @@ enum ErrorExit {
 
 /// Error enum representing errors in the cli.
 #[derive(Debug)]
-enum ExecutionError {
+pub(crate) enum ExecutionError {
     // Errors seen when rubyfmt is executing
     RubyfmtError(rubyfmt::RichFormatError, String),
     // Errors seen when performing IO s
@@ -36,8 +36,8 @@ enum ExecutionError {
 
 /// Rubyfmt CLI
 #[derive(Debug, Parser)]
-#[clap(name = "rubyfmt", bin_name = "rubyfmt", author, version, about, long_about = None)]
-struct CommandlineOpts {
+#[clap(long_about = None)]
+pub(crate) struct CommandlineOpts {
     /// Turn on check mode. This outputs diffs of inputs to STDOUT. Will exit non-zero when differences are detected.
     #[clap(short, long)]
     check: bool,
@@ -131,7 +131,7 @@ fn print_error(msg: &str, file_path: Option<&str>) {
     eprintln!("{}\n{}", first_line, msg);
 }
 
-fn handle_execution_error(opts: &CommandlineOpts, err: ExecutionError) {
+pub(crate) fn handle_execution_error(opts: &CommandlineOpts, err: ExecutionError) {
     let mut exit_type = ErrorExit::NoExit;
     // If include_paths are empty, this is operating on STDIN which should always exit
     if opts.fail_fast || opts.include_paths.is_empty() {
@@ -227,9 +227,7 @@ fn file_walker_builder(include_paths: Vec<&String>, include_gitignored: bool) ->
 }
 
 // Parse command line arguments. Expand any input files.
-fn get_command_line_options() -> CommandlineOpts {
-    let opts = CommandlineOpts::parse();
-
+fn get_command_line_options(opts: CommandlineOpts) -> CommandlineOpts {
     let mut expanded_paths: Vec<String> = Vec::new();
 
     for path in opts.include_paths {
@@ -342,7 +340,7 @@ fn iterate_input_files(opts: &CommandlineOpts, f: InputFunc) {
 type InputFunc<'a> = &'a dyn Fn((&Path, &[u8]));
 type FormattingFunc<'a> = &'a dyn Fn((&Path, &[u8], Option<Vec<u8>>));
 
-fn iterate_formatted(opts: &CommandlineOpts, f: FormattingFunc) {
+pub(crate) fn iterate_formatted(opts: &CommandlineOpts, f: FormattingFunc) {
     iterate_input_files(
         opts,
         &|(file_path, before)| match rubyfmt_string(opts, before) {
@@ -362,14 +360,14 @@ fn puts_stdout(input: &[u8]) {
     io::stdout().flush().expect("flush works");
 }
 
-fn main() {
+pub(crate) fn main(opts: CommandlineOpts) {
     ctrlc::set_handler(move || {
         eprintln!("`rubyfmt` process was terminated. Exiting...");
         exit(1);
     })
     .expect("Error setting Ctrl-C handler");
 
-    let opts = get_command_line_options();
+    let opts = get_command_line_options(opts);
     init_logger();
 
     match opts {

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -42,7 +42,7 @@ pub(crate) struct CommandlineOpts {
     #[clap(short, long)]
     check: bool,
 
-    /// Turn on to ignore gitignored files. Gitignored files are not considered by rubyfmt by default.
+    /// Turn on to format gitignored files. Gitignored files are ignored by default.
     #[clap(long, name = "include-gitignored")]
     include_gitignored: bool,
 

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -59,22 +59,20 @@ pub(crate) struct CommandlineOpts {
     fail_fast: bool,
 
     /// Write files back in place, do not write output to STDOUT.
-    #[clap(short, long, name = "in-place")]
+    #[clap(short, long, name = "in-place", hide = true)]
     in_place: bool,
 
     /// When reading from stdin, treat the input as if it were at this path.
     /// This allows .rubyfmtignore and .gitignore patterns to be applied to stdin input.
-    #[clap(long, name = "stdin-filepath", conflicts_with_all = ["include-paths", "in-place"])]
+    #[clap(long, name = "stdin-filepath", conflicts_with_all = ["paths", "in-place"])]
     stdin_filepath: Option<String>,
 
-    /// Paths for rubyfmt to analyze. By default the output will be printed to STDOUT. See `--in-place` to write files back in-place.
+    /// Paths to format. To format the entire project, run `rv fmt .`{n}
     /// Acceptable paths are:{n}
     /// - File paths (i.e lib/foo/bar.rb){n}
     /// - Directories (i.e. lib/foo/){n}
     /// - Input files (i.e. @/tmp/files.txt). These files must contain one file path or directory per line
-    ///
-    /// rubyfmt will use these as input.{n}
-    #[clap(name = "include-paths")]
+    #[clap(name = "paths")]
     include_paths: Vec<String>,
 }
 
@@ -368,8 +366,13 @@ pub(crate) fn main(opts: CommandlineOpts) {
     })
     .expect("Error setting Ctrl-C handler");
 
-    let opts = get_command_line_options(opts);
+    let mut opts = get_command_line_options(opts);
     init_logger();
+
+    if opts.include_paths.is_empty() {
+        // turn on stdout output
+        opts.in_place = false;
+    }
 
     match opts {
         CommandlineOpts { check: true, .. } => {

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -259,6 +259,7 @@ fn iterate_input_files(opts: &CommandlineOpts, f: InputFunc) {
         if io::stdin().is_terminal() {
             // Call executable with `--help` args to print help statement
             let mut command = Command::new(std::env::current_exe().unwrap());
+            command.arg("fmt");
             command.arg("--help");
             command.spawn().unwrap().wait().unwrap();
             return;

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -71,6 +71,10 @@ pub(crate) struct CommandlineOpts {
     /// - Input files (i.e. @/tmp/files.txt). These files must contain one file path or directory per line
     #[clap(name = "paths")]
     include_paths: Vec<String>,
+
+    /// If stdin is attached to a terminal.
+    #[clap(long, name = "is-tty", hide = true, default_value_t = io::stdin().is_terminal())]
+    is_tty: bool,
 }
 
 /******************************************************/
@@ -221,14 +225,20 @@ fn file_walker_builder(include_paths: Vec<&String>, include_gitignored: bool) ->
 }
 
 // Parse command line arguments. Expand any input files.
+//
+// When `include_paths` is empty:
+//   - tty → format the current directory in place (include_paths = ["."])
+//   - piped → format stdin to stdout
+// When paths are given, the `--stdout` flag is respected, and stdin is ignored.
 fn get_command_line_options(opts: CommandlineOpts) -> CommandlineOpts {
     let mut opts = opts;
 
-    // Default to formatting the current directory if stdin is a tty, implying no pipe
-    if io::stdin().is_terminal() && opts.include_paths.is_empty() {
-        opts.include_paths.push(".".into());
-    } else {
-        opts.stdout = true;
+    if opts.include_paths.is_empty() {
+        if opts.is_tty {
+            opts.include_paths.push(".".into());
+        } else {
+            opts.stdout = true;
+        }
     }
 
     let mut expanded_paths: Vec<String> = Vec::new();
@@ -457,6 +467,7 @@ mod tests {
             stdout: false,
             stdin_filepath: None,
             include_paths: vec![],
+            is_tty: false,
         }
     }
 
@@ -795,6 +806,94 @@ mod tests {
         let opts = make_opts();
         let expanded = get_command_line_options(opts);
         assert!(expanded.include_paths.is_empty());
+    }
+
+    // ==========================================================================
+    //     rv fmt .              → format current directory in place
+    //     rv fmt                → act like `rv fmt .`
+    //     rv fmt . --stdout     → format current directory to stdout
+    //     rv fmt                → piped: format stdin to stdout
+    //     rv fmt --stdout       → piped: format stdin to stdout
+    //     rv fmt .              → piped: format dir in place, ignore stdin
+    //     rv fmt . --stdout     → piped: format dir to stdout, ignore stdin
+    // ==========================================================================
+
+    /// `rv fmt .` — format the current directory in place.
+    #[test]
+    fn fmt_dot_formats_current_dir_in_place() {
+        let opts = opts_with(|o| {
+            o.include_paths = vec![".".to_string()];
+            o.is_tty = true;
+        });
+        let expanded = get_command_line_options(opts);
+        assert_eq!(expanded.include_paths, vec!["."]);
+        assert!(!expanded.stdout);
+        assert!(!expanded.check);
+        assert!(!expanded.fail_fast);
+    }
+
+    /// `rv fmt` with an interactive tty should default to formatting the
+    /// current directory in place.
+    #[test]
+    fn fmt_without_paths_defaults_to_current_dir_on_tty() {
+        let opts = opts_with(|o| o.is_tty = true);
+        let expanded = get_command_line_options(opts);
+        assert_eq!(expanded.include_paths, vec!["."]);
+        assert!(!expanded.stdout);
+    }
+
+    /// `rv fmt . --stdout` — format the current directory and write to stdout.
+    #[test]
+    fn fmt_dot_with_stdout_flag_writes_to_stdout() {
+        let opts = opts_with(|o| {
+            o.stdout = true;
+            o.is_tty = true;
+            o.include_paths = vec![".".to_string()];
+        });
+        let expanded = get_command_line_options(opts);
+        assert_eq!(expanded.include_paths, vec!["."]);
+        assert!(expanded.stdout);
+    }
+
+    /// `echo "..." | rv fmt` — piped stdin is formatted and printed to stdout.
+    #[test]
+    fn fmt_with_piped_stdin_formats_stdin_to_stdout() {
+        let opts = make_opts();
+        let expanded = get_command_line_options(opts);
+        assert!(expanded.include_paths.is_empty());
+        assert!(expanded.stdout);
+    }
+
+    /// `echo "..." | rv fmt --stdout` — same as above, --stdout is explicit.
+    #[test]
+    fn fmt_with_piped_stdin_and_stdout_flag_formats_stdin_to_stdout() {
+        let opts = opts_with(|o| o.stdout = true);
+        let expanded = get_command_line_options(opts);
+        assert!(expanded.include_paths.is_empty());
+        assert!(expanded.stdout);
+    }
+
+    /// `echo "..." | rv fmt .` — piped stdin is ignored; the directory is
+    /// formatted in place.
+    #[test]
+    fn fmt_dot_with_piped_stdin_ignores_stdin_and_formats_in_place() {
+        let opts = opts_with(|o| o.include_paths = vec![".".to_string()]);
+        let expanded = get_command_line_options(opts);
+        assert_eq!(expanded.include_paths, vec!["."]);
+        assert!(!expanded.stdout);
+    }
+
+    /// `echo "..." | rv fmt . --stdout` — piped stdin is ignored; the
+    /// directory is formatted and the result is written to stdout.
+    #[test]
+    fn fmt_dot_with_piped_stdin_and_stdout_flag_ignores_stdin() {
+        let opts = opts_with(|o| {
+            o.stdout = true;
+            o.include_paths = vec![".".to_string()];
+        });
+        let expanded = get_command_line_options(opts);
+        assert_eq!(expanded.include_paths, vec!["."]);
+        assert!(expanded.stdout);
     }
 
     // ==========================================================================

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -9,7 +9,7 @@ use std::ffi::OsStr;
 use std::fs::{File, OpenOptions, read};
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::Path;
-use std::process::{Command, exit};
+use std::process::exit;
 use std::sync::{Arc, LazyLock, Mutex};
 
 static MAGIC_COMMENT_REGEX: LazyLock<Regex> =
@@ -249,17 +249,7 @@ fn get_command_line_options(opts: CommandlineOpts) -> CommandlineOpts {
 
 fn iterate_input_files(opts: &CommandlineOpts, f: InputFunc) {
     if opts.include_paths.is_empty() {
-        // If not include paths are present, assume user is passing via STDIN
         let mut buffer = Vec::new();
-
-        if io::stdin().is_terminal() {
-            // Call executable with `--help` args to print help statement
-            let mut command = Command::new(std::env::current_exe().unwrap());
-            command.arg("fmt");
-            command.arg("--help");
-            command.spawn().unwrap().wait().unwrap();
-            return;
-        }
 
         io::stdin()
             .read_to_end(&mut buffer)
@@ -362,12 +352,16 @@ fn puts_stdout(input: &[u8]) {
 }
 
 pub(crate) fn main(opts: CommandlineOpts) {
-    let mut opts = get_command_line_options(opts);
-
-    if opts.include_paths.is_empty() {
-        // turn on stdout output
-        opts.in_place = false;
-    }
+    // Default to formatting the current directory if stdin is a tty, implying no pipe
+    let opts = if opts.include_paths.is_empty() && io::stdin().is_terminal() {
+        get_command_line_options(CommandlineOpts {
+            include_paths: vec![".".into()],
+            in_place: true,
+            ..opts
+        })
+    } else {
+        get_command_line_options(opts)
+    };
 
     match opts {
         CommandlineOpts { check: true, .. } => {

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -82,7 +82,7 @@ pub(crate) struct CommandlineOpts {
 
 fn handle_io_error(err: io::Error, source: &str, error_exit: ErrorExit) {
     let msg = format!("Rubyfmt experienced an IO error: {}", err);
-    print_error(&msg, Some(source));
+    print_error(&msg, Some(source), &mut io::stderr().lock());
 
     if error_exit == ErrorExit::Exit {
         exit(rubyfmt::FormatError::IOError as i32);
@@ -91,7 +91,7 @@ fn handle_io_error(err: io::Error, source: &str, error_exit: ErrorExit) {
 
 fn handle_ignore_error(err: ignore::Error, error_exit: ErrorExit) {
     let msg = format!("Rubyfmt experienced an error searching for files: {}", err);
-    print_error(&msg, None);
+    print_error(&msg, None, &mut io::stderr().lock());
     if error_exit == ErrorExit::Exit {
         exit(rubyfmt::FormatError::IOError as i32);
     }
@@ -108,25 +108,25 @@ fn handle_rubyfmt_error(err: rubyfmt::RichFormatError, source: &str, error_exit:
     match err {
         SyntaxError => {
             let msg = "Rubyfmt detected a syntax error in the ruby code being executed";
-            print_error(msg, Some(source));
+            print_error(msg, Some(source), &mut io::stderr().lock());
             e();
         }
         IOError(ioe) => {
             let msg = format!("Rubyfmt experienced an IO error: {}", ioe);
-            print_error(&msg, Some(source));
+            print_error(&msg, Some(source), &mut io::stderr().lock());
             e();
         }
     }
 }
 
-fn print_error(msg: &str, file_path: Option<&str>) {
+fn print_error(msg: &str, file_path: Option<&str>, writer: &mut impl Write) {
     let mut first_line: String = "Error!".to_string();
 
     if let Some(line) = file_path {
         first_line = format!("Error! source: {}", line);
     }
 
-    eprintln!("{}\n{}", first_line, msg);
+    let _ = writeln!(writer, "{}\n{}", first_line, msg);
 }
 
 pub(crate) fn handle_execution_error(opts: &CommandlineOpts, err: ExecutionError) {
@@ -188,15 +188,14 @@ fn rubyfmt_string(
 /******************************************************/
 
 /// Check if a path should be ignored based on .gitignore and .rubyfmtignore patterns.
-/// The path should be relative to the current working directory.
-fn is_path_ignored(path: &Path, include_gitignored: bool) -> bool {
-    let cwd = std::env::current_dir().unwrap();
-    let mut builder = GitignoreBuilder::new(&cwd);
+/// `path` is interpreted relative to `root` (the directory that holds the ignore files).
+fn is_path_ignored(root: &Path, path: &Path, include_gitignored: bool) -> bool {
+    let mut builder = GitignoreBuilder::new(root);
 
     if !include_gitignored {
-        builder.add(".gitignore");
+        builder.add(root.join(".gitignore"));
     }
-    builder.add(".rubyfmtignore");
+    builder.add(root.join(".rubyfmtignore"));
 
     if let Ok(gitignore) = builder.build() {
         let is_dir = path.is_dir();
@@ -269,7 +268,11 @@ fn iterate_input_files(opts: &CommandlineOpts, f: InputFunc) {
 
         let path = if let Some(stdin_filepath) = &opts.stdin_filepath {
             let path = Path::new(stdin_filepath);
-            if is_path_ignored(path, opts.include_gitignored) {
+            if is_path_ignored(
+                &std::env::current_dir().unwrap(),
+                path,
+                opts.include_gitignored,
+            ) {
                 // Print unchanged output for ignored files unless we're in check mode
                 if !opts.check {
                     puts_stdout(&buffer);
@@ -447,5 +450,729 @@ pub(crate) fn main(opts: CommandlineOpts) {
             Some(fmtted) => puts_stdout(&fmtted),
             None => puts_stdout(before),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::sync::{Arc, Mutex};
+
+    // ---------------------------------------------------------------------
+    // Test helpers
+    // ---------------------------------------------------------------------
+
+    fn make_opts() -> CommandlineOpts {
+        CommandlineOpts {
+            check: false,
+            include_gitignored: false,
+            header_opt_in: false,
+            header_opt_out: false,
+            fail_fast: false,
+            in_place: true,
+            stdin_filepath: None,
+            include_paths: vec![],
+        }
+    }
+
+    fn opts_with(overrides: impl FnOnce(&mut CommandlineOpts)) -> CommandlineOpts {
+        let mut opts = make_opts();
+        overrides(&mut opts);
+        opts
+    }
+
+    type CollectedInputs = Vec<(String, Vec<u8>)>;
+    type CollectedFormatting = Vec<(String, Vec<u8>, Option<Vec<u8>>)>;
+
+    /// Run a callback and collect every `(path, buffer)` pair yielded by
+    /// `iterate_input_files` into a shared `Vec`.
+    fn collect_inputs(opts: &CommandlineOpts) -> Vec<(String, Vec<u8>)> {
+        let collected: Arc<Mutex<CollectedInputs>> = Arc::new(Mutex::new(Vec::new()));
+        iterate_input_files(opts, &|(path, buffer)| {
+            collected
+                .lock()
+                .unwrap()
+                .push((path.display().to_string(), buffer.to_vec()));
+        });
+        Arc::try_unwrap(collected)
+            .ok()
+            .and_then(|m| m.into_inner().ok())
+            .unwrap_or_default()
+    }
+
+    /// Same as `collect_inputs` but discards buffers.
+    fn collect_paths(opts: &CommandlineOpts) -> Vec<String> {
+        collect_inputs(opts).into_iter().map(|(p, _)| p).collect()
+    }
+
+    // ==========================================================================
+    // MAGIC COMMENT PARSING (via rubyfmt_string)
+    // ==========================================================================
+
+    #[test]
+    fn magic_comment_with_opt_in_and_header_true_is_formatted() {
+        let opts = opts_with(|o| o.header_opt_in = true);
+        let result = rubyfmt_string(&opts, b"# rubyfmt: true\nx = 1").unwrap();
+        assert!(
+            result.is_some(),
+            "File with `rubyfmt: true` should be formatted"
+        );
+    }
+
+    #[test]
+    fn magic_comment_with_opt_in_and_header_false_is_skipped() {
+        let opts = opts_with(|o| o.header_opt_in = true);
+        let result = rubyfmt_string(&opts, b"# rubyfmt: false\nx = 1").unwrap();
+        assert!(
+            result.is_none(),
+            "File with `rubyfmt: false` should not be formatted when opt-in is enabled"
+        );
+    }
+
+    #[test]
+    fn magic_comment_with_opt_in_but_no_header_is_skipped() {
+        let opts = opts_with(|o| o.header_opt_in = true);
+        let result = rubyfmt_string(&opts, b"x = 1").unwrap();
+        assert!(
+            result.is_none(),
+            "File without magic comment should not be formatted when opt-in is enabled"
+        );
+    }
+
+    #[test]
+    fn magic_comment_with_opt_out_and_header_true_is_formatted() {
+        let opts = opts_with(|o| o.header_opt_out = true);
+        let result = rubyfmt_string(&opts, b"# rubyfmt: true\nx = 1").unwrap();
+        assert!(
+            result.is_some(),
+            "File with `rubyfmt: true` should be formatted with opt-out"
+        );
+    }
+
+    #[test]
+    fn magic_comment_with_opt_out_and_header_false_is_skipped() {
+        let opts = opts_with(|o| o.header_opt_out = true);
+        let result = rubyfmt_string(&opts, b"# rubyfmt: false\nx = 1").unwrap();
+        assert!(
+            result.is_none(),
+            "File with `rubyfmt: false` should not be formatted when opt-out is enabled"
+        );
+    }
+
+    #[test]
+    fn magic_comment_is_ignored_when_no_opt_flag_is_set() {
+        let opts = make_opts();
+        let result = rubyfmt_string(&opts, b"# rubyfmt: false\nx = 1").unwrap();
+        assert!(
+            result.is_some(),
+            "Without opt-in/opt-out, magic comments should be ignored and file formatted"
+        );
+    }
+
+    #[test]
+    fn magic_comment_accepts_whitespace_variations() {
+        let opts = opts_with(|o| o.header_opt_in = true);
+
+        let cases: &[(&[u8], &str)] = &[
+            (b"# rubyfmt: true\nx = 1", "leading space before rubyfmt"),
+            (b"#rubyfmt: true\nx = 1", "no space after hash"),
+            (
+                b"# rubyfmt: true  \nx = 1",
+                "trailing whitespace before newline",
+            ),
+        ];
+
+        for (input, label) in cases {
+            let result = rubyfmt_string(&opts, input)
+                .unwrap_or_else(|e| panic!("{label}: expected Ok, got {e:?}"));
+            assert!(result.is_some(), "{label}: should be treated as opted in");
+        }
+
+        let negative = rubyfmt_string(&opts, b"#rubyfmt: false\nx = 1").unwrap();
+        assert!(
+            negative.is_none(),
+            "no-space variant should also be respected when value is `false`"
+        );
+    }
+
+    #[test]
+    fn magic_comment_only_reads_first_500_bytes() {
+        let opts = opts_with(|o| o.header_opt_in = true);
+        let mut buffer = vec![b' '; 600];
+        buffer[0..15].copy_from_slice(b"# rubyfmt: true");
+        let result = rubyfmt_string(&opts, &buffer).unwrap();
+        assert!(
+            result.is_some(),
+            "Should find magic comment in first 500 bytes"
+        );
+    }
+
+    #[test]
+    fn magic_comment_not_found_when_beyond_500_bytes() {
+        let opts = opts_with(|o| o.header_opt_in = true);
+        let mut buffer = vec![b' '; 600];
+        buffer[501..516].copy_from_slice(b"# rubyfmt: true");
+        let result = rubyfmt_string(&opts, &buffer).unwrap();
+        assert!(
+            result.is_none(),
+            "Should not find magic comment beyond first 500 bytes"
+        );
+    }
+
+    #[test]
+    fn valid_ruby_is_formatted() {
+        let opts = make_opts();
+        let formatted = rubyfmt_string(&opts, b"x=1").unwrap().expect("ok");
+        let expected = rubyfmt::format_buffer(b"x=1").unwrap();
+        assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn syntax_error_is_reported_as_syntax_error() {
+        let opts = make_opts();
+        let err = rubyfmt_string(&opts, b"def \n").expect_err("invalid ruby should error");
+        assert!(
+            matches!(err, rubyfmt::RichFormatError::SyntaxError),
+            "expected SyntaxError, got {err:?}"
+        );
+    }
+
+    // ==========================================================================
+    // COMMAND LINE OPTION PARSING (clap)
+    // ==========================================================================
+
+    #[test]
+    fn clap_parsing_default_options() {
+        let opts = CommandlineOpts::try_parse_from(["fmt"]).unwrap();
+        assert!(!opts.check);
+        assert!(!opts.include_gitignored);
+        assert!(!opts.header_opt_in);
+        assert!(!opts.header_opt_out);
+        assert!(!opts.fail_fast);
+        assert!(!opts.in_place);
+        assert!(opts.stdin_filepath.is_none());
+        assert!(opts.include_paths.is_empty());
+    }
+
+    #[test]
+    fn clap_parsing_check_mode_long_flag() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "--check"]).unwrap();
+        assert!(opts.check);
+    }
+
+    #[test]
+    fn clap_parsing_check_mode_short_flag() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "-c"]).unwrap();
+        assert!(opts.check);
+    }
+
+    #[test]
+    fn clap_parsing_include_gitignored_flag() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "--include-gitignored"]).unwrap();
+        assert!(opts.include_gitignored);
+    }
+
+    #[test]
+    fn clap_parsing_header_opt_in_flag() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "--header-opt-in"]).unwrap();
+        assert!(opts.header_opt_in);
+    }
+
+    #[test]
+    fn clap_parsing_header_opt_out_flag() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "--header-opt-out"]).unwrap();
+        assert!(opts.header_opt_out);
+    }
+
+    #[test]
+    fn clap_parsing_fail_fast_flag() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "--fail-fast"]).unwrap();
+        assert!(opts.fail_fast);
+    }
+
+    #[test]
+    fn clap_parsing_stdin_filepath_flag() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "--stdin-filepath", "test.rb"]).unwrap();
+        assert_eq!(opts.stdin_filepath.as_deref(), Some("test.rb"));
+        // stdin-filepath is mutually exclusive with paths.
+        let err =
+            CommandlineOpts::try_parse_from(["fmt", "--stdin-filepath", "test.rb", "lib/foo.rb"])
+                .unwrap_err();
+        assert!(
+            err.to_string()
+                .to_lowercase()
+                .contains("cannot be used with"),
+            "expected conflict error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn clap_parsing_paths() {
+        let opts = CommandlineOpts::try_parse_from(["fmt", "lib/", "app/main.rb"]).unwrap();
+        assert_eq!(opts.include_paths, vec!["lib/", "app/main.rb"]);
+    }
+
+    #[test]
+    fn clap_parsing_combined_options() {
+        let opts = CommandlineOpts::try_parse_from([
+            "fmt",
+            "--check",
+            "--header-opt-in",
+            "--fail-fast",
+            "lib/",
+        ])
+        .unwrap();
+        assert!(opts.check);
+        assert!(opts.header_opt_in);
+        assert!(opts.fail_fast);
+        assert_eq!(opts.include_paths, vec!["lib/"]);
+    }
+
+    // ==========================================================================
+    // INPUT FILE EXPANSION (get_command_line_options)
+    // ==========================================================================
+
+    #[test]
+    fn expansion_reads_paths_from_at_file() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "path/to/file1.rb").unwrap();
+        writeln!(tmp, "path/to/file2.rb").unwrap();
+        writeln!(tmp, "directory/").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        let opts = opts_with(|o| o.include_paths = vec![format!("@{path}")]);
+        let expanded = get_command_line_options(opts);
+        assert_eq!(
+            expanded.include_paths,
+            vec!["path/to/file1.rb", "path/to/file2.rb", "directory/"]
+        );
+        assert!(!expanded.check);
+        assert!(!expanded.fail_fast);
+    }
+
+    #[test]
+    fn expansion_preserves_all_other_options() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        let opts = opts_with(|o| {
+            o.check = true;
+            o.include_gitignored = true;
+            o.header_opt_in = true;
+            o.fail_fast = true;
+            o.in_place = false;
+            o.stdin_filepath = Some("test.rb".to_string());
+            o.include_paths = vec![format!("@{path}")];
+        });
+
+        let expanded = get_command_line_options(opts);
+        assert!(expanded.check);
+        assert!(expanded.include_gitignored);
+        assert!(expanded.header_opt_in);
+        assert!(expanded.fail_fast);
+        assert_eq!(expanded.stdin_filepath.as_deref(), Some("test.rb"));
+    }
+
+    #[test]
+    fn expansion_keeps_paths_without_at_prefix_untouched() {
+        let opts = opts_with(|o| {
+            o.include_paths = vec!["lib/foo.rb".to_string(), "dir/".to_string()];
+        });
+        let expanded = get_command_line_options(opts);
+        assert_eq!(expanded.include_paths, vec!["lib/foo.rb", "dir/"]);
+    }
+
+    #[test]
+    fn expansion_mixes_literal_and_at_paths() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "expanded/path.rb").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        let opts = opts_with(|o| {
+            o.include_paths = vec!["lib/".to_string(), format!("@{path}")];
+        });
+        let expanded = get_command_line_options(opts);
+        assert_eq!(expanded.include_paths, vec!["lib/", "expanded/path.rb"]);
+    }
+
+    #[test]
+    fn expansion_with_empty_at_file_yields_no_extra_paths() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        let opts = opts_with(|o| o.include_paths = vec![format!("@{path}")]);
+        let expanded = get_command_line_options(opts);
+        assert!(expanded.include_paths.is_empty());
+    }
+
+    #[test]
+    fn expansion_with_no_include_paths_is_a_noop() {
+        let opts = make_opts();
+        let expanded = get_command_line_options(opts);
+        assert!(expanded.include_paths.is_empty());
+    }
+
+    // ==========================================================================
+    // FILE WALKER BUILDER
+    // ==========================================================================
+
+    #[test]
+    fn file_walker_builder_accepts_a_single_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let builder = file_walker_builder(vec![&path], false);
+        // The builder must be constructible and iterable. The exact yield depends
+        // on WalkBuilder internals (it emits the root directory itself), so we
+        // only smoke-test that iteration produces something without panicking.
+        let mut iter = builder.build();
+        let _ = iter.next();
+    }
+
+    #[test]
+    fn file_walker_builder_accepts_multiple_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path1 = tmp.path().to_str().unwrap().to_string();
+        let path2 = tmp.path().join("subdir");
+        std::fs::create_dir_all(&path2).unwrap();
+        let path2 = path2.to_str().unwrap().to_string();
+
+        let builder = file_walker_builder(vec![&path1, &path2], true);
+        // Smoke check: builder builds without panicking and is iterable.
+        let _ = builder.build().next();
+    }
+
+    #[test]
+    fn file_walker_builder_respects_rubyfmtignore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        std::fs::write(root.join("keep.rb"), "x = 1").unwrap();
+        std::fs::write(root.join("skip.rb"), "y = 2").unwrap();
+        std::fs::write(root.join(".rubyfmtignore"), "skip.rb\n").unwrap();
+
+        let opts = opts_with(|o| {
+            o.in_place = false;
+            o.include_paths = vec![root.to_str().unwrap().to_string()];
+        });
+
+        let paths = collect_paths(&opts);
+        let names: Vec<&str> = paths
+            .iter()
+            .map(|p| p.rsplit_once('/').map(|(_, n)| n).unwrap_or(p.as_str()))
+            .collect();
+        assert!(
+            names.contains(&"keep.rb"),
+            "keep.rb should be walked, got names = {names:?}"
+        );
+        assert!(
+            !names.contains(&"skip.rb"),
+            "skip.rb should be excluded by .rubyfmtignore, got names = {names:?}"
+        );
+    }
+
+    // ==========================================================================
+    // PATH IGNORING (is_path_ignored)
+    // ==========================================================================
+
+    fn write_ignore(dir: &Path, name: &str, contents: &str) {
+        let mut f = File::create(dir.join(name)).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn is_path_ignored_matches_gitignore_pattern() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ignore(tmp.path(), ".gitignore", "*.rb\n");
+
+        assert!(
+            is_path_ignored(tmp.path(), Path::new("test.rb"), false),
+            "*.rb in .gitignore should match test.rb"
+        );
+        assert!(
+            !is_path_ignored(tmp.path(), Path::new("README.md"), false),
+            "README.md should not be matched"
+        );
+    }
+
+    #[test]
+    fn is_path_ignored_ignores_gitignore_when_flag_is_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ignore(tmp.path(), ".gitignore", "*.rb\n");
+
+        assert!(
+            !is_path_ignored(tmp.path(), Path::new("test.rb"), true),
+            "with include_gitignored=true, .gitignore patterns must not apply"
+        );
+        // .rubyfmtignore should still apply.
+        write_ignore(tmp.path(), ".rubyfmtignore", "special.rb\n");
+        assert!(
+            is_path_ignored(tmp.path(), Path::new("special.rb"), true),
+            ".rubyfmtignore patterns apply regardless of include_gitignored"
+        );
+    }
+
+    #[test]
+    fn is_path_ignored_matches_rubyfmtignore_pattern() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ignore(tmp.path(), ".rubyfmtignore", "ignored_file.rb\n");
+
+        assert!(
+            is_path_ignored(tmp.path(), Path::new("ignored_file.rb"), false),
+            "ignored_file.rb should be ignored by .rubyfmtignore"
+        );
+        assert!(
+            !is_path_ignored(tmp.path(), Path::new("lib/active.rb"), false),
+            "lib/active.rb should not be ignored"
+        );
+    }
+
+    #[test]
+    fn is_path_ignored_returns_false_when_no_ignore_files_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(
+            !is_path_ignored(tmp.path(), Path::new("test.rb"), false),
+            "Without ignore files, nothing should be ignored"
+        );
+    }
+
+    #[test]
+    fn is_path_ignored_matches_directory_pattern() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ignore(tmp.path(), ".gitignore", "vendor/\n");
+
+        assert!(
+            is_path_ignored(tmp.path(), Path::new("vendor/bundle"), false),
+            "vendor/ pattern should match vendor/bundle"
+        );
+    }
+
+    #[test]
+    fn is_path_ignored_matches_nested_pattern() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ignore(tmp.path(), ".gitignore", "**/tmp/\n");
+
+        assert!(
+            is_path_ignored(tmp.path(), Path::new("app/tmp/cache"), false),
+            "**/tmp/ pattern should match app/tmp/cache"
+        );
+    }
+
+    #[test]
+    fn is_path_ignored_does_not_match_unrelated_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ignore(tmp.path(), ".gitignore", "*.log\n");
+
+        assert!(
+            !is_path_ignored(tmp.path(), Path::new("test.rb"), false),
+            "test.rb should not be ignored when .gitignore only covers *.log"
+        );
+    }
+
+    // ==========================================================================
+    // ERROR HANDLING
+    // ==========================================================================
+
+    #[test]
+    fn handle_execution_error_with_io_error_does_not_exit_when_paths_are_non_empty() {
+        // fail_fast=false and non-empty include_paths => ErrorExit::NoExit,
+        // so the test must continue past this call.
+        let opts = opts_with(|o| o.include_paths = vec!["somefile.rb".to_string()]);
+        let err = ExecutionError::IOError(
+            io::Error::new(io::ErrorKind::NotFound, "file not found"),
+            "test.rb".to_string(),
+        );
+        handle_execution_error(&opts, err);
+    }
+
+    #[test]
+    fn handle_execution_error_with_syntax_error_does_not_exit_when_paths_are_non_empty() {
+        let opts = opts_with(|o| o.include_paths = vec!["somefile.rb".to_string()]);
+        let err = ExecutionError::RubyfmtError(
+            rubyfmt::RichFormatError::SyntaxError,
+            "test.rb".to_string(),
+        );
+        handle_execution_error(&opts, err);
+    }
+
+    // Note: the fail_fast and empty-paths branches of `handle_execution_error`
+    // call `std::process::exit(...)` and therefore cannot be exercised from a
+    // unit test in the same process.
+
+    // ==========================================================================
+    // PRINT ERROR
+    // ==========================================================================
+
+    #[test]
+    fn print_error_includes_source_when_provided() {
+        let mut out = Vec::new();
+        print_error("boom", Some("lib/foo.rb"), &mut out);
+        let rendered = String::from_utf8(out).unwrap();
+        assert!(
+            rendered.contains("Error! source: lib/foo.rb"),
+            "expected source in header, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("boom"),
+            "expected message body, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn print_error_omits_source_when_not_provided() {
+        let mut out = Vec::new();
+        print_error("boom", None, &mut out);
+        let rendered = String::from_utf8(out).unwrap();
+        assert!(
+            rendered.contains("Error!\n"),
+            "expected plain `Error!` header when no source, got: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("source:"),
+            "should not contain `source:` when no source given, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("boom"),
+            "expected message body, got: {rendered:?}"
+        );
+    }
+
+    // ==========================================================================
+    // ITERATE_INPUT_FILES
+    // ==========================================================================
+
+    #[test]
+    fn iterate_input_files_yields_single_file_with_contents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("test.rb");
+        std::fs::write(&file_path, b"x = 1\n").unwrap();
+
+        let opts = opts_with(|o| {
+            o.in_place = false;
+            o.include_paths = vec![file_path.to_str().unwrap().to_string()];
+        });
+
+        let collected = collect_inputs(&opts);
+        assert_eq!(collected.len(), 1);
+        assert!(
+            collected[0].0.ends_with("test.rb"),
+            "expected test.rb path, got {}",
+            collected[0].0
+        );
+        assert_eq!(collected[0].1, b"x = 1\n");
+    }
+
+    #[test]
+    fn iterate_input_files_walks_only_rb_files_in_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("a.rb"), "").unwrap();
+        std::fs::write(dir.join("b.rb"), "").unwrap();
+        std::fs::write(dir.join("readme.txt"), "").unwrap();
+
+        let opts = opts_with(|o| {
+            o.in_place = false;
+            o.include_paths = vec![dir.to_str().unwrap().to_string()];
+        });
+
+        let paths = collect_paths(&opts);
+        let names: Vec<&str> = paths
+            .iter()
+            .map(|p| p.rsplit_once('/').map(|(_, n)| n).unwrap_or(p.as_str()))
+            .collect();
+        assert!(names.contains(&"a.rb"), "expected a.rb, got {names:?}");
+        assert!(names.contains(&"b.rb"), "expected b.rb, got {names:?}");
+        assert!(
+            !names.contains(&"readme.txt"),
+            "non-.rb file should be excluded, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn iterate_input_files_excludes_files_in_rubyfmtignore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("keep.rb"), "x = 1").unwrap();
+        std::fs::write(dir.join("skip.rb"), "y = 2").unwrap();
+        std::fs::write(dir.join(".rubyfmtignore"), "skip.rb\n").unwrap();
+
+        let opts = opts_with(|o| {
+            o.in_place = false;
+            o.include_paths = vec![dir.to_str().unwrap().to_string()];
+        });
+
+        let names: Vec<String> = collect_paths(&opts)
+            .into_iter()
+            .map(|p| p.rsplit_once('/').map(|(_, n)| n.to_string()).unwrap_or(p))
+            .collect();
+        assert!(names.contains(&"keep.rb".to_string()));
+        assert!(
+            !names.contains(&"skip.rb".to_string()),
+            "skip.rb must be excluded by .rubyfmtignore, got {names:?}"
+        );
+    }
+
+    // ==========================================================================
+    // ITERATE_FORMATTED
+    // ==========================================================================
+
+    #[test]
+    fn iterate_formatted_emits_a_formatting_decision_for_each_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("clean.rb");
+        std::fs::write(&file, b"x = 1\n").unwrap();
+
+        let opts = opts_with(|o| {
+            o.in_place = false;
+            o.include_paths = vec![file.to_str().unwrap().to_string()];
+        });
+
+        let collected: Arc<Mutex<CollectedFormatting>> = Arc::new(Mutex::new(Vec::new()));
+        iterate_formatted(&opts, &|(path, before, after)| {
+            collected
+                .lock()
+                .unwrap()
+                .push((path.display().to_string(), before.to_vec(), after));
+        });
+
+        let results = Arc::try_unwrap(collected)
+            .ok()
+            .and_then(|m| m.into_inner().ok())
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        let (path, before, after) = &results[0];
+        assert!(path.ends_with("clean.rb"));
+        assert_eq!(before, b"x = 1\n");
+        let after = after.as_ref().expect("format should succeed");
+        let expected = rubyfmt::format_buffer(b"x = 1\n").unwrap();
+        assert_eq!(after, &expected);
+    }
+
+    #[test]
+    fn iterate_formatted_skipped_when_header_opt_in_does_not_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("opted_out.rb");
+        std::fs::write(&file, b"# rubyfmt: false\nx = 1\n").unwrap();
+
+        let opts = opts_with(|o| {
+            o.in_place = false;
+            o.header_opt_in = true;
+            o.include_paths = vec![file.to_str().unwrap().to_string()];
+        });
+
+        let collected: Arc<Mutex<Vec<Option<Vec<u8>>>>> = Arc::new(Mutex::new(Vec::new()));
+        iterate_formatted(&opts, &|(_, _, after)| {
+            collected.lock().unwrap().push(after);
+        });
+
+        let results = Arc::try_unwrap(collected)
+            .ok()
+            .and_then(|m| m.into_inner().ok())
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].is_none(),
+            "header-opt-in should yield None for files without `rubyfmt: true`"
+        );
     }
 }

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -1,5 +1,3 @@
-#![deny(warnings, missing_copy_implementations)]
-
 use clap::Parser;
 use ignore::WalkBuilder;
 use ignore::gitignore::GitignoreBuilder;
@@ -34,7 +32,7 @@ pub(crate) enum ExecutionError {
 }
 
 /// Rubyfmt CLI
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, Clone)]
 #[clap(long_about = None)]
 pub(crate) struct CommandlineOpts {
     /// Turn on check mode. This outputs diffs of inputs to STDOUT. Will exit non-zero when differences are detected.
@@ -57,13 +55,13 @@ pub(crate) struct CommandlineOpts {
     #[clap(long, name = "fail-fast")]
     fail_fast: bool,
 
-    /// Write files back in place, do not write output to STDOUT.
-    #[clap(short, long, name = "in-place", hide = true)]
-    in_place: bool,
+    /// Write formatted files to STDOUT, instead of formatting in place.
+    #[clap(short, long)]
+    stdout: bool,
 
     /// When reading from stdin, treat the input as if it were at this path.
     /// This allows .rubyfmtignore and .gitignore patterns to be applied to stdin input.
-    #[clap(long, name = "stdin-filepath", conflicts_with_all = ["paths", "in-place"])]
+    #[clap(long, name = "stdin-filepath", conflicts_with_all = ["paths"])]
     stdin_filepath: Option<String>,
 
     /// Paths to format. To format the entire project, run `rv fmt .`{n}
@@ -224,6 +222,15 @@ fn file_walker_builder(include_paths: Vec<&String>, include_gitignored: bool) ->
 
 // Parse command line arguments. Expand any input files.
 fn get_command_line_options(opts: CommandlineOpts) -> CommandlineOpts {
+    let mut opts = opts;
+
+    // Default to formatting the current directory if stdin is a tty, implying no pipe
+    if io::stdin().is_terminal() && opts.include_paths.is_empty() {
+        opts.include_paths.push(".".into());
+    } else {
+        opts.stdout = true;
+    }
+
     let mut expanded_paths: Vec<String> = Vec::new();
 
     for path in opts.include_paths {
@@ -352,16 +359,7 @@ fn puts_stdout(input: &[u8]) {
 }
 
 pub(crate) fn main(opts: CommandlineOpts) {
-    // Default to formatting the current directory if stdin is a tty, implying no pipe
-    let opts = if opts.include_paths.is_empty() && io::stdin().is_terminal() {
-        get_command_line_options(CommandlineOpts {
-            include_paths: vec![".".into()],
-            in_place: true,
-            ..opts
-        })
-    } else {
-        get_command_line_options(opts)
-    };
+    let opts = get_command_line_options(opts);
 
     match opts {
         CommandlineOpts { check: true, .. } => {
@@ -411,30 +409,30 @@ pub(crate) fn main(opts: CommandlineOpts) {
             }
         }
 
-        CommandlineOpts { in_place: true, .. } => {
-            iterate_formatted(&opts, &|(file_path, before, after)| match after {
-                Some(fmtted) if fmtted.ne(before) => {
-                    let file_write = OpenOptions::new()
-                        .write(true)
-                        .truncate(true)
-                        .open(file_path)
-                        .and_then(|mut file| file.write_all(&fmtted));
-
-                    match file_write {
-                        Ok(_) => {}
-                        Err(e) => handle_execution_error(
-                            &opts,
-                            ExecutionError::IOError(e, file_path.display().to_string()),
-                        ),
-                    }
-                }
-                _ => {}
+        CommandlineOpts { stdout: true, .. } => {
+            iterate_formatted(&opts, &|(_, before, after)| match after {
+                Some(fmtted) => puts_stdout(&fmtted),
+                None => puts_stdout(before),
             })
         }
 
-        _ => iterate_formatted(&opts, &|(_, before, after)| match after {
-            Some(fmtted) => puts_stdout(&fmtted),
-            None => puts_stdout(before),
+        _ => iterate_formatted(&opts, &|(file_path, before, after)| match after {
+            Some(fmtted) if fmtted.ne(before) => {
+                let file_write = OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(file_path)
+                    .and_then(|mut file| file.write_all(&fmtted));
+
+                match file_write {
+                    Ok(_) => {}
+                    Err(e) => handle_execution_error(
+                        &opts,
+                        ExecutionError::IOError(e, file_path.display().to_string()),
+                    ),
+                }
+            }
+            _ => {}
         }),
     }
 }
@@ -456,7 +454,7 @@ mod tests {
             header_opt_in: false,
             header_opt_out: false,
             fail_fast: false,
-            in_place: true,
+            stdout: false,
             stdin_filepath: None,
             include_paths: vec![],
         }
@@ -636,7 +634,7 @@ mod tests {
         assert!(!opts.header_opt_in);
         assert!(!opts.header_opt_out);
         assert!(!opts.fail_fast);
-        assert!(!opts.in_place);
+        assert!(!opts.stdout);
         assert!(opts.stdin_filepath.is_none());
         assert!(opts.include_paths.is_empty());
     }
@@ -747,7 +745,7 @@ mod tests {
             o.include_gitignored = true;
             o.header_opt_in = true;
             o.fail_fast = true;
-            o.in_place = false;
+            o.stdout = false;
             o.stdin_filepath = Some("test.rb".to_string());
             o.include_paths = vec![format!("@{path}")];
         });
@@ -838,7 +836,7 @@ mod tests {
         std::fs::write(root.join(".rubyfmtignore"), "skip.rb\n").unwrap();
 
         let opts = opts_with(|o| {
-            o.in_place = false;
+            o.stdout = false;
             o.include_paths = vec![root.to_str().unwrap().to_string()];
         });
 
@@ -1034,7 +1032,7 @@ mod tests {
         std::fs::write(&file_path, b"x = 1\n").unwrap();
 
         let opts = opts_with(|o| {
-            o.in_place = false;
+            o.stdout = false;
             o.include_paths = vec![file_path.to_str().unwrap().to_string()];
         });
 
@@ -1057,7 +1055,7 @@ mod tests {
         std::fs::write(dir.join("readme.txt"), "").unwrap();
 
         let opts = opts_with(|o| {
-            o.in_place = false;
+            o.stdout = false;
             o.include_paths = vec![dir.to_str().unwrap().to_string()];
         });
 
@@ -1083,7 +1081,7 @@ mod tests {
         std::fs::write(dir.join(".rubyfmtignore"), "skip.rb\n").unwrap();
 
         let opts = opts_with(|o| {
-            o.in_place = false;
+            o.stdout = false;
             o.include_paths = vec![dir.to_str().unwrap().to_string()];
         });
 
@@ -1109,7 +1107,7 @@ mod tests {
         std::fs::write(&file, b"x = 1\n").unwrap();
 
         let opts = opts_with(|o| {
-            o.in_place = false;
+            o.stdout = false;
             o.include_paths = vec![file.to_str().unwrap().to_string()];
         });
 
@@ -1141,7 +1139,7 @@ mod tests {
         std::fs::write(&file, b"# rubyfmt: false\nx = 1\n").unwrap();
 
         let opts = opts_with(|o| {
-            o.in_place = false;
+            o.stdout = false;
             o.header_opt_in = true;
             o.include_paths = vec![file.to_str().unwrap().to_string()];
         });

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -942,7 +942,7 @@ mod tests {
         let paths = collect_paths(&opts);
         let names: Vec<&str> = paths
             .iter()
-            .map(|p| p.rsplit_once('/').map(|(_, n)| n).unwrap_or(p.as_str()))
+            .filter_map(|p| Path::new(p).file_name().and_then(|n| n.to_str()))
             .collect();
         assert!(
             names.contains(&"keep.rb"),
@@ -1184,14 +1184,18 @@ mod tests {
             o.include_paths = vec![dir.to_str().unwrap().to_string()];
         });
 
-        let names: Vec<String> = collect_paths(&opts)
-            .into_iter()
-            .map(|p| p.rsplit_once('/').map(|(_, n)| n.to_string()).unwrap_or(p))
+        let paths = collect_paths(&opts);
+        let names: Vec<&str> = paths
+            .iter()
+            .filter_map(|p| Path::new(p).file_name().and_then(|n| n.to_str()))
             .collect();
-        assert!(names.contains(&"keep.rb".to_string()));
         assert!(
-            !names.contains(&"skip.rb".to_string()),
-            "skip.rb must be excluded by .rubyfmtignore, got {names:?}"
+            names.contains(&"keep.rb"),
+            "keep.rb should be walked, got names = {names:?}"
+        );
+        assert!(
+            !names.contains(&"skip.rb"),
+            "skip.rb should be excluded by .rubyfmtignore, got names = {names:?}"
         );
     }
 

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -363,12 +363,6 @@ fn puts_stdout(input: &[u8]) {
 }
 
 pub(crate) fn main(opts: CommandlineOpts) {
-    ctrlc::set_handler(move || {
-        eprintln!("`rubyfmt` process was terminated. Exiting...");
-        exit(1);
-    })
-    .expect("Error setting Ctrl-C handler");
-
     let mut opts = get_command_line_options(opts);
     init_logger();
 

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -1161,7 +1161,7 @@ mod tests {
         let paths = collect_paths(&opts);
         let names: Vec<&str> = paths
             .iter()
-            .map(|p| p.rsplit_once('/').map(|(_, n)| n).unwrap_or(p.as_str()))
+            .filter_map(|p| Path::new(p).file_name().and_then(|n| n.to_str()))
             .collect();
         assert!(names.contains(&"a.rb"), "expected a.rb, got {names:?}");
         assert!(names.contains(&"b.rb"), "expected b.rb, got {names:?}");

--- a/crates/rv/src/commands/fmt/rubyfmt.rs
+++ b/crates/rv/src/commands/fmt/rubyfmt.rs
@@ -4,7 +4,6 @@ use clap::Parser;
 use ignore::WalkBuilder;
 use ignore::gitignore::GitignoreBuilder;
 use regex::Regex;
-use rubyfmt::init_logger;
 use similar::TextDiff;
 use std::ffi::OsStr;
 use std::fs::{File, OpenOptions, read};
@@ -364,7 +363,6 @@ fn puts_stdout(input: &[u8]) {
 
 pub(crate) fn main(opts: CommandlineOpts) {
     let mut opts = get_command_line_options(opts);
-    init_logger();
 
     if opts.include_paths.is_empty() {
         // turn on stdout output

--- a/crates/rv/src/main.rs
+++ b/crates/rv/src/main.rs
@@ -22,6 +22,7 @@ pub mod update;
 
 use crate::commands::cache::{CacheCommandArgs, cache};
 use crate::commands::clean_install::{CleanInstallArgs, ci};
+use crate::commands::fmt::{FmtArgs, fmt};
 use crate::commands::ruby::{RubyArgs, ruby};
 use crate::commands::run::{RunArgs, run};
 use crate::commands::self_cmd::{SelfArgs, self_cmd};
@@ -132,6 +133,8 @@ enum Commands {
         dont_delimit_trailing_values = true
     )]
     Run(RunArgs),
+    #[command(about = "Format Ruby files consistently")]
+    Fmt(FmtArgs),
 }
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]
@@ -309,6 +312,7 @@ async fn run_cmd(global_args: &GlobalArgs, command: Commands) -> Result<()> {
         Commands::Shell(shell_args) => shell(global_args, &mut Cli::command(), shell_args)?,
         Commands::Tool(tool_args) => tool(global_args, tool_args).await?,
         Commands::Run(run_args) => run(global_args, run_args).await?,
+        Commands::Fmt(fmt_args) => fmt(global_args, fmt_args).await?,
     };
 
     Ok(())


### PR DESCRIPTION
Building on [librubyfmt](https://github.com/fables-tales/rubyfmt/tree/trunk/librubyfmt), this PR adds an `rv fmt` command. The interface is quite similar to `rubyfmt`, but `--in-place` is now the default mode, and it will format the current directory/package when run without arguments. IMO our goal here is something familiar across languages and ecosystems, and `go fmt` and `cargo fmt` both work this way.