### PR TITLE
fix multi-line Powershell configuration

### DIFF
--- a/crates/rv/src/commands/shell.rs
+++ b/crates/rv/src/commands/shell.rs
@@ -142,8 +142,8 @@ fn setup(shell: Shell) -> Result<()> {
                 Use \"rvw\" or \"rv.exe\" to invoke rv from the command line.
                 On PowerShell, \"rv\" conflicts with the built-in Remove-Variable alias.
 
-                Add-Content -Path $PROFILE -Value 'Invoke-Expression (& \"{rv}\" shell init powershell)'
-                Add-Content -Path $PROFILE -Value 'Invoke-Expression (& \"{rv}\" shell completions powershell)'
+                Add-Content -Path $PROFILE -Value '& \"{rv}\" shell init powershell | Out-String | Invoke-Expression'
+                Add-Content -Path $PROFILE -Value '& \"{rv}\" shell completions powershell | Out-String | Invoke-Expression'
             "};
 
             Ok(())

--- a/crates/rv/src/commands/shell/init.rs
+++ b/crates/rv/src/commands/shell/init.rs
@@ -77,10 +77,10 @@ pub fn init(shell: Shell) -> Result<()> {
                 }}
                 Copy-Item Function:\\prompt Function:\\__rv_original_prompt
                 function global:prompt {{
-                    Invoke-Expression (& '{current_exe}' shell env powershell)
+                    & '{current_exe}' shell env powershell | Out-String | Invoke-Expression
                     __rv_original_prompt
                 }}
-                Invoke-Expression (& '{current_exe}' shell env powershell)
+                & '{current_exe}' shell env powershell | Out-String | Invoke-Expression
             "};
         }
     }

--- a/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__init_test__powershell_shell_init_succeeds.snap
+++ b/crates/rv/tests/integration_tests/shell/snapshots/integration_tests__shell__init_test__powershell_shell_init_succeeds.snap
@@ -7,7 +7,7 @@ if (Test-Path Function:\__rv_original_prompt) {
 }
 Copy-Item Function:\prompt Function:\__rv_original_prompt
 function global:prompt {
-    Invoke-Expression (& '/tmp/bin/rv' shell env powershell)
+    & '/tmp/bin/rv' shell env powershell | Out-String | Invoke-Expression
     __rv_original_prompt
 }
-Invoke-Expression (& '/tmp/bin/rv' shell env powershell)
+& '/tmp/bin/rv' shell env powershell | Out-String | Invoke-Expression


### PR DESCRIPTION
I think this will fix #740. In my testing this patch was enough to automatically change which version got run by `ruby` as I changed directories in Powershell.
