### PR TITLE
Support JRuby Installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1419,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2662,7 +2662,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2972,7 +2972,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3030,7 +3030,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3807,7 +3807,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4474,7 +4474,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/rv-ruby/src/canonical_name.rs
+++ b/crates/rv-ruby/src/canonical_name.rs
@@ -5,11 +5,43 @@ use crate::{
 use std::fmt::Display;
 
 pub trait CanonicalName: Display {
+    /// The name users see, with the redundant `ruby-` prefix dropped for CRuby.
+    ///
+    /// Only CRuby is stripped: other engines carry their name as part of their
+    /// identity, so `jruby-10.1.1.0` stays intact rather than becoming `j10.1.1.0`.
     fn canonical_name(&self) -> String {
-        self.to_string().replace("ruby-", "")
+        let name = self.to_string();
+        match name.strip_prefix("ruby-") {
+            Some(stripped) => stripped.to_string(),
+            None => name,
+        }
     }
 }
 
 impl CanonicalName for RubyRequest {}
 impl CanonicalName for ReleasedRubyRequest {}
 impl CanonicalName for RubyVersion {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[track_caller]
+    fn name(version: &str) -> String {
+        RubyVersion::from_str(version).unwrap().canonical_name()
+    }
+
+    #[test]
+    fn strips_the_cruby_prefix() {
+        assert_eq!(name("ruby-3.4.1"), "3.4.1");
+        assert_eq!(name("ruby-3.5.0-preview1"), "3.5.0-preview1");
+    }
+
+    #[test]
+    fn keeps_other_engine_names_intact() {
+        assert_eq!(name("jruby-10.1.1.0"), "jruby-10.1.1.0");
+        assert_eq!(name("jruby-9.4.15.0"), "jruby-9.4.15.0");
+        assert_eq!(name("truffleruby-24.1.1"), "truffleruby-24.1.1");
+    }
+}

--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -18,14 +18,24 @@ use tracing::instrument;
 use crate::version::RubyVersion;
 
 /// Returns the possible Ruby executable names for the current platform, in priority order.
-/// On Windows, checks `ruby.exe` (standard RubyInstaller2) then `ruby.cmd` (batch wrapper).
+/// On Windows, checks `ruby.exe` (standard RubyInstaller2), then `ruby.cmd` (batch wrapper),
+/// then `ruby.bat` (JRuby, which ships no `ruby.exe`).
 /// On Unix systems (macOS, Linux), it's just `ruby`.
 fn ruby_executable_names() -> &'static [&'static str] {
     if cfg!(windows) {
-        &["ruby.exe", "ruby.cmd"]
+        &["ruby.exe", "ruby.cmd", "ruby.bat"]
     } else {
         &["ruby"]
     }
+}
+
+/// Windows script wrappers that can't take arguments containing `(`, `)`, or `?`
+/// directly, due to Rust's CVE-2024-24576 mitigation (1.77.2+).
+fn is_windows_script_wrapper(ruby_bin: &Utf8Path) -> bool {
+    cfg!(windows)
+        && ruby_bin
+            .extension()
+            .is_some_and(|ext| ext == "cmd" || ext == "bat")
 }
 
 /// Find the Ruby executable in a directory's `bin/` subdirectory.
@@ -305,10 +315,11 @@ fn extract_ruby_info(ruby_bin: &Utf8PathBuf) -> Result<Ruby, RubyError> {
         puts(Object.const_defined?(:RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : '')
     "#;
 
-    // On Windows, .cmd wrappers can't receive arguments containing special characters like (, ), ?
-    // due to Rust's CVE-2024-24576 mitigation (1.77.2+). Following uv's pattern: write the probe
-    // script to a temp file, then invoke through cmd.exe /c to bypass the restriction entirely.
-    let output = if cfg!(windows) && ruby_bin.extension().is_some_and(|ext| ext == "cmd") {
+    // On Windows, .cmd and .bat wrappers can't receive arguments containing special characters
+    // like (, ), ? due to Rust's CVE-2024-24576 mitigation (1.77.2+). Following uv's pattern:
+    // write the probe script to a temp file, then invoke through cmd.exe /c to bypass the
+    // restriction entirely.
+    let output = if is_windows_script_wrapper(ruby_bin) {
         let probe_script = ruby_bin.with_file_name("_rv_probe.rb");
         std::fs::write(&probe_script, full_script).map_err(|_| RubyError::InvalidRubyExecutable)?;
         let result = Command::new("cmd")

--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -6,12 +6,15 @@ use futures_util::StreamExt;
 use indicatif::ProgressStyle;
 use owo_colors::OwoColorize;
 use reqwest::StatusCode;
+use std::borrow::Cow;
+use std::io::Read as _;
 use std::path::{Component, PathBuf};
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, info_span};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use rv_platform::HostPlatform;
+use rv_ruby::engine::RubyEngine;
 use rv_ruby::request::RubyRequest;
 
 use crate::progress::WorkProgress;
@@ -64,9 +67,12 @@ pub(crate) async fn install(
 
     let request = config.ruby_request();
 
-    let version = match request {
-        RubyRequest::Dev => "dev".to_string(),
-        RubyRequest::Released(_) => config.find_matching_remote_ruby().await?.number(),
+    let (engine, version) = match request {
+        RubyRequest::Dev => (RubyEngine::Ruby, "dev".to_string()),
+        RubyRequest::Released(_) => {
+            let matched = config.find_matching_remote_ruby().await?;
+            (matched.engine.clone(), matched.number())
+        }
     };
 
     let install_dir = match install_dir {
@@ -86,15 +92,17 @@ pub(crate) async fn install(
     let archive_path = if let Some(path) = tarball_path {
         path
     } else {
-        download_tarball(config, &version, &progress).await?
+        download_tarball(config, &engine, &version, &progress).await?
     };
 
-    extract_ruby_archive(&archive_path, &install_dir, &version)?;
+    extract_ruby_archive(&archive_path, &install_dir, &engine, &version)?;
 
     let installed_version = if version == "dev" {
         "ruby-dev".cyan().to_string()
-    } else {
+    } else if engine == RubyEngine::Ruby {
         format!("Ruby version {}", version.cyan())
+    } else {
+        format!("{engine} version {}", version.cyan())
     };
 
     println!("Installed {installed_version} to {}", install_dir.cyan());
@@ -105,16 +113,18 @@ pub(crate) async fn install(
 // downloads a remote ruby archive (tarball or zip)
 async fn download_tarball(
     config: &Config,
+    engine: &RubyEngine,
     version: &str,
     progress: &WorkProgress,
 ) -> Result<Utf8PathBuf> {
     let host = HostPlatform::current()?;
-    let mut url = ruby_url(version, &host);
+    let ext = archive_ext_for(engine, &host);
+    let mut url = ruby_url(engine, version, &host);
 
     if version == "dev" && !host.is_windows() {
         url = find_latest_ruby_dev_url(&url).await?;
     }
-    let archive_path = archive_cache_path(config, &url, &host);
+    let archive_path = archive_cache_path(config, &url, ext);
 
     let cache_dir = archive_path.parent().unwrap();
     if !cache_dir.exists() {
@@ -127,7 +137,7 @@ async fn download_tarball(
             archive_path.cyan()
         );
     } else {
-        download_ruby_archive(config, &url, &archive_path, version, progress, &host).await?;
+        download_ruby_archive(config, &url, &archive_path, version, progress, ext).await?;
     }
 
     Ok(archive_path)
@@ -138,27 +148,44 @@ fn valid_archive_exists(path: &Utf8Path) -> bool {
     fs_err::metadata(path).is_ok_and(|m| m.is_file() && m.len() > 0)
 }
 
-fn ruby_url(version: &str, host: &HostPlatform) -> String {
-    let download_base =
-        std::env::var("RV_INSTALL_URL").unwrap_or_else(|_| download_base_for(version, host));
-    let download_path = download_path_for(version, host);
+/// JRuby ships `.zip` on Windows and `.tar.gz` elsewhere, not RubyInstaller2's `.7z`.
+fn archive_ext_for(engine: &RubyEngine, host: &HostPlatform) -> &'static str {
+    match engine {
+        RubyEngine::JRuby if host.is_windows() => "zip",
+        RubyEngine::JRuby => "tar.gz",
+        _ => host.archive_ext(),
+    }
+}
+
+fn ruby_url(engine: &RubyEngine, version: &str, host: &HostPlatform) -> String {
+    let download_base = std::env::var("RV_INSTALL_URL")
+        .unwrap_or_else(|_| download_base_for(engine, version, host));
+    let download_path = download_path_for(engine, version, host);
 
     format!("{download_base}/{download_path}")
 }
 
-fn download_base_for(version: &str, host: &HostPlatform) -> String {
-    if host.is_windows() {
-        "https://github.com/oneclick/rubyinstaller2/releases/download".to_owned()
-    } else if version == "dev" {
-        "https://github.com/spinel-coop/rv-ruby-dev/releases/latest/download".to_owned()
-    } else {
-        "https://github.com/spinel-coop/rv-ruby/releases/latest/download".to_owned()
+fn download_base_for(engine: &RubyEngine, version: &str, host: &HostPlatform) -> String {
+    match engine {
+        RubyEngine::JRuby => "https://github.com/jruby/jruby/releases/download".to_owned(),
+        _ if host.is_windows() => {
+            "https://github.com/oneclick/rubyinstaller2/releases/download".to_owned()
+        }
+        _ if version == "dev" => {
+            "https://github.com/spinel-coop/rv-ruby-dev/releases/latest/download".to_owned()
+        }
+        _ => "https://github.com/spinel-coop/rv-ruby/releases/latest/download".to_owned(),
     }
 }
 
-fn download_path_for(version: &str, host: &HostPlatform) -> String {
+fn download_path_for(engine: &RubyEngine, version: &str, host: &HostPlatform) -> String {
     let arch = host.ruby_arch_str();
-    let ext = host.archive_ext();
+    let ext = archive_ext_for(engine, host);
+
+    // JRuby archives are universal, so the path carries no arch.
+    if *engine == RubyEngine::JRuby {
+        return format!("{version}/jruby-bin-{version}.{ext}");
+    }
 
     if host.is_windows() {
         if version == "dev" {
@@ -189,8 +216,7 @@ async fn find_latest_ruby_dev_url(url: &str) -> Result<String> {
     }
 }
 
-fn archive_cache_path(config: &Config, url: impl AsRef<str>, host: &HostPlatform) -> Utf8PathBuf {
-    let ext = host.archive_ext();
+fn archive_cache_path(config: &Config, url: impl AsRef<str>, ext: &str) -> Utf8PathBuf {
     let cache_key = rv_cache::cache_digest(url.as_ref());
     config
         .cache
@@ -199,8 +225,7 @@ fn archive_cache_path(config: &Config, url: impl AsRef<str>, host: &HostPlatform
         .join(format!("{cache_key}.{ext}"))
 }
 
-fn temp_archive_path(config: &Config, url: impl AsRef<str>, host: &HostPlatform) -> Utf8PathBuf {
-    let ext = host.archive_ext();
+fn temp_archive_path(config: &Config, url: impl AsRef<str>, ext: &str) -> Utf8PathBuf {
     let cache_key = rv_cache::cache_digest(url.as_ref());
     config
         .cache
@@ -254,7 +279,7 @@ async fn download_ruby_archive(
     archive_path: &Utf8PathBuf,
     version: &str,
     progress: &WorkProgress,
-    host: &HostPlatform,
+    ext: &str,
 ) -> Result<()> {
     debug!("Downloading archive from {url}");
     let redirects = true;
@@ -287,7 +312,7 @@ async fn download_ruby_archive(
     let _guard = span.enter();
 
     // Write the archive bytes to the filesystem.
-    let temp_path = temp_archive_path(config, url, host);
+    let temp_path = temp_archive_path(config, url, ext);
     if let Err(e) = write_to_filesystem(
         response,
         &temp_path,
@@ -332,9 +357,23 @@ async fn fetch_url(url: &str, redirects: bool) -> Result<reqwest::Response> {
     Ok(request_builder.send().await?)
 }
 
+/// Must match what `Config::is_requested_ruby_installed_in_dir` looks for.
+fn install_dir_name(engine: &RubyEngine, version: &str) -> String {
+    format!("{engine}-{version}")
+}
+
+/// rv-ruby tarballs nest as `rv-ruby@{version}/{version}/…`; JRuby's have a single root.
+fn tarball_strip_components(engine: &RubyEngine) -> usize {
+    match engine {
+        RubyEngine::JRuby => 1,
+        _ => 2,
+    }
+}
+
 fn extract_ruby_archive(
     archive_path: &Utf8Path,
     rubies_dir: &Utf8Path,
+    engine: &RubyEngine,
     version: &str,
 ) -> Result<()> {
     let host = HostPlatform::current()?;
@@ -346,29 +385,66 @@ fn extract_ruby_archive(
         fs_err::create_dir_all(rubies_dir)?;
     }
 
+    let dir_name = install_dir_name(engine, version);
+
     // Determine archive type by extension
     let extension = archive_path.extension().unwrap_or("");
     match extension {
-        "zip" => extract_zip(archive_path, rubies_dir, version),
-        "7z" => extract_7z(archive_path, rubies_dir, version, &host),
-        _ => extract_tarball(archive_path, rubies_dir, version),
+        // Both zip sources, RubyInstaller2 and JRuby on Windows, have a single root.
+        "zip" => extract_zip(archive_path, rubies_dir, &dir_name, 1),
+        "7z" => extract_7z(archive_path, rubies_dir, &dir_name, version, &host),
+        _ => extract_tarball(
+            archive_path,
+            rubies_dir,
+            &dir_name,
+            tarball_strip_components(engine),
+        ),
     }
 }
 
-fn extract_tarball(tarball_path: &Utf8Path, rubies_dir: &Utf8Path, version: &str) -> Result<()> {
+fn extract_tarball(
+    tarball_path: &Utf8Path,
+    rubies_dir: &Utf8Path,
+    dir_name: &str,
+    strip_components: usize,
+) -> Result<()> {
     let tarball = fs_err::File::open(tarball_path)?;
     let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(tarball));
-    let dst_dir: PathBuf = rubies_dir.as_std_path().join(format!("ruby-{}", version));
+    let dst_dir: PathBuf = rubies_dir.as_std_path().join(dir_name);
+
+    let mut long_name: Option<PathBuf> = None;
+
     for e in archive.entries()? {
         let mut entry = e?;
-        let entry_path = entry.path()?;
+
+        // Paths over 100 bytes live in a preceding `././@LongLink` record. The tar
+        // crate only applies those under GNU magic, but JRuby's tarballs pair them
+        // with POSIX ustar magic, so the record surfaces here and the real entry
+        // arrives truncated. Apply the name ourselves.
+        match entry.header().entry_type() {
+            tar::EntryType::GNULongName => {
+                let mut name = String::new();
+                entry.read_to_string(&mut name)?;
+                long_name = Some(PathBuf::from(name.trim_end_matches('\0')));
+                continue;
+            }
+            // Same, for long symlink targets. Unused here; skip so it isn't written out.
+            tar::EntryType::GNULongLink => continue,
+            _ => {}
+        }
+
+        let entry_path = match long_name.take() {
+            Some(name) => Cow::Owned(name),
+            None => entry.path()?,
+        };
 
         let mut dst_file = dst_dir.to_path_buf();
 
-        // Strip the first two path components
+        // Strip the archive's own root directories
         let mut path = entry_path.components();
-        path.next();
-        path.next();
+        for _ in 0..strip_components {
+            path.next();
+        }
 
         // Copied from
         // https://github.com/composefs/tar-rs/blob/fc459c149f83bf4daceaa52e17d351989002e1a9/src/entry.rs#L404-L419,
@@ -395,32 +471,48 @@ fn extract_tarball(tarball_path: &Utf8Path, rubies_dir: &Utf8Path, version: &str
             }
         }
 
+        // `Entry::unpack` won't create parents the way `Archive::unpack` does, and
+        // JRuby's tarball lists files before their directory entries.
+        if let Some(parent) = dst_file.parent() {
+            fs_err::create_dir_all(parent)?;
+        }
+
         crate::tar_utils::unpack_entry(&mut entry, &dst_file)?;
     }
     Ok(())
 }
 
-fn extract_zip(zip_path: &Utf8Path, rubies_dir: &Utf8Path, version: &str) -> Result<()> {
+fn extract_zip(
+    zip_path: &Utf8Path,
+    rubies_dir: &Utf8Path,
+    dir_name: &str,
+    strip_components: usize,
+) -> Result<()> {
     let file = fs_err::File::open(zip_path)?;
     let mut archive = zip::ZipArchive::new(file)?;
+    let dst_dir = rubies_dir.join(dir_name);
+    fs_err::create_dir_all(&dst_dir)?;
 
     for i in 0..archive.len() {
         let mut entry = archive.by_index(i)?;
-        let entry_path = entry.name().to_string();
-
-        // Normalize path: repackage RubyInstaller format to rv format
-        let path = entry_path
-            .replace(
-                &format!("rubyinstaller-{}", version),
-                &format!("ruby-{}", version),
-            )
-            .replace('\\', "/"); // Normalize Windows path separators
+        let path = entry.name().replace('\\', "/"); // Normalize Windows path separators
 
         if path.contains("..") {
             return Err(Error::DirectoryTraversalError(path));
         }
 
-        let dst = rubies_dir.join(&path);
+        // Rebuild under `dir_name` so the archive's own root doesn't name the install.
+        let relative: Vec<&str> = path
+            .split('/')
+            .filter(|part| !part.is_empty() && *part != ".")
+            .skip(strip_components)
+            .collect();
+
+        if relative.is_empty() {
+            continue;
+        }
+
+        let dst = dst_dir.join(relative.join("/"));
 
         if entry.is_dir() {
             fs_err::create_dir_all(&dst)?;
@@ -446,6 +538,7 @@ fn entry_extract_fn(
 fn extract_7z(
     archive_path: &Utf8Path,
     rubies_dir: &Utf8Path,
+    dir_name: &str,
     version: &str,
     host: &HostPlatform,
 ) -> Result<()> {
@@ -465,7 +558,7 @@ fn extract_7z(
     } else {
         rubies_dir.join(format!("rubyinstaller-{}-1-{arch}", version))
     };
-    let target_dir = rubies_dir.join(format!("ruby-{}", version));
+    let target_dir = rubies_dir.join(dir_name);
 
     if extracted_dir.exists() {
         fs_err::rename(&extracted_dir, &target_dir)?;
@@ -484,7 +577,7 @@ mod tests {
     #[test]
     fn test_ruby_url_unix() {
         let host = HostPlatform::from_target_triple("aarch64-apple-darwin").unwrap();
-        let url = ruby_url("3.4.1", &host);
+        let url = ruby_url(&RubyEngine::Ruby, "3.4.1", &host);
 
         assert_eq!(
             url,
@@ -495,7 +588,7 @@ mod tests {
     #[test]
     fn test_ruby_url_windows() {
         let host = HostPlatform::from_target_triple("x86_64-pc-windows-msvc").unwrap();
-        let url = ruby_url("3.4.1", &host);
+        let url = ruby_url(&RubyEngine::Ruby, "3.4.1", &host);
 
         assert_eq!(
             url,
@@ -506,7 +599,7 @@ mod tests {
     #[test]
     fn test_ruby_url_windows_arm64() {
         let host = HostPlatform::from_target_triple("aarch64-pc-windows-msvc").unwrap();
-        let url = ruby_url("3.4.1", &host);
+        let url = ruby_url(&RubyEngine::Ruby, "3.4.1", &host);
 
         assert_eq!(
             url,
@@ -517,7 +610,7 @@ mod tests {
     #[test]
     fn test_ruby_url_unix_dev() {
         let host = HostPlatform::from_target_triple("aarch64-apple-darwin").unwrap();
-        let url = ruby_url("dev", &host);
+        let url = ruby_url(&RubyEngine::Ruby, "dev", &host);
 
         assert_eq!(
             url,
@@ -528,11 +621,203 @@ mod tests {
     #[test]
     fn test_ruby_url_windows_dev() {
         let host = HostPlatform::from_target_triple("x86_64-pc-windows-msvc").unwrap();
-        let url = ruby_url("dev", &host);
+        let url = ruby_url(&RubyEngine::Ruby, "dev", &host);
 
         assert_eq!(
             url,
             "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.7z"
+        );
+    }
+
+    #[test]
+    fn test_jruby_url_is_universal_across_unix_platforms() {
+        // One archive for every platform, so the URL must not vary with host arch.
+        for triple in [
+            "aarch64-apple-darwin",
+            "x86_64-apple-darwin",
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-musl",
+        ] {
+            let host = HostPlatform::from_target_triple(triple).unwrap();
+            let url = ruby_url(&RubyEngine::JRuby, "10.1.1.0", &host);
+
+            assert_eq!(
+                url,
+                "https://github.com/jruby/jruby/releases/download/10.1.1.0/jruby-bin-10.1.1.0.tar.gz",
+                "wrong JRuby url for {triple}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_jruby_url_windows_uses_zip() {
+        let host = HostPlatform::from_target_triple("x86_64-pc-windows-msvc").unwrap();
+        let url = ruby_url(&RubyEngine::JRuby, "9.4.15.0", &host);
+
+        assert_eq!(
+            url,
+            "https://github.com/jruby/jruby/releases/download/9.4.15.0/jruby-bin-9.4.15.0.zip"
+        );
+    }
+
+    #[test]
+    fn test_archive_ext_for() {
+        let mac = HostPlatform::from_target_triple("aarch64-apple-darwin").unwrap();
+        let win = HostPlatform::from_target_triple("x86_64-pc-windows-msvc").unwrap();
+
+        assert_eq!(archive_ext_for(&RubyEngine::Ruby, &mac), "tar.gz");
+        assert_eq!(archive_ext_for(&RubyEngine::Ruby, &win), "7z");
+        assert_eq!(archive_ext_for(&RubyEngine::JRuby, &mac), "tar.gz");
+        assert_eq!(archive_ext_for(&RubyEngine::JRuby, &win), "zip");
+    }
+
+    #[test]
+    fn test_install_dir_name_matches_request_display() {
+        use rv_ruby::request::RubyRequest;
+        use std::str::FromStr;
+
+        // The directory rv extracts into has to be the one it later looks for.
+        for request in ["ruby-3.4.1", "jruby-10.1.1.0", "jruby-9.4.12.1"] {
+            let parsed = RubyRequest::from_str(request).unwrap();
+            let version = rv_ruby::version::RubyVersion::try_from(parsed).unwrap();
+
+            assert_eq!(
+                install_dir_name(&version.engine, &version.number()),
+                request
+            );
+        }
+    }
+
+    #[test]
+    fn test_tarball_strip_components() {
+        assert_eq!(tarball_strip_components(&RubyEngine::Ruby), 2);
+        assert_eq!(tarball_strip_components(&RubyEngine::JRuby), 1);
+    }
+
+    #[test]
+    fn test_extract_zip_uses_the_given_dir_name_not_the_archive_root() {
+        // The archive's own root must not decide the install dir name.
+        let temp_dir = TempDir::new().unwrap();
+        let rubies_dir = temp_dir.child("rubies");
+        rubies_dir.create_dir_all().unwrap();
+
+        let zip_path = temp_dir.child("jruby.zip");
+        {
+            let file = std::fs::File::create(zip_path.path()).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options: zip::write::SimpleFileOptions = Default::default();
+            zip.add_directory::<_, ()>("some-unexpected-root/", options)
+                .unwrap();
+            zip.add_directory::<_, ()>("some-unexpected-root/bin/", options)
+                .unwrap();
+            zip.start_file("some-unexpected-root/bin/ruby.bat", options)
+                .unwrap();
+            zip.write_all(b"fake jruby launcher").unwrap();
+            zip.finish().unwrap();
+        }
+
+        extract_zip(
+            Utf8Path::from_path(zip_path.path()).unwrap(),
+            Utf8Path::from_path(rubies_dir.path()).unwrap(),
+            &install_dir_name(&RubyEngine::JRuby, "10.1.1.0"),
+            1,
+        )
+        .unwrap();
+
+        let launcher = rubies_dir
+            .child("jruby-10.1.1.0")
+            .child("bin")
+            .child("ruby.bat");
+        assert!(
+            launcher.exists(),
+            "zip should land under the requested dir name regardless of its own root"
+        );
+        assert_eq!(
+            std::fs::read_to_string(launcher.path()).unwrap(),
+            "fake jruby launcher"
+        );
+    }
+
+    #[test]
+    fn test_extract_zip_rejects_directory_traversal() {
+        let temp_dir = TempDir::new().unwrap();
+        let rubies_dir = temp_dir.child("rubies");
+        rubies_dir.create_dir_all().unwrap();
+
+        let zip_path = temp_dir.child("evil.zip");
+        {
+            let file = std::fs::File::create(zip_path.path()).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options: zip::write::SimpleFileOptions = Default::default();
+            zip.start_file("root/../../escaped.txt", options).unwrap();
+            zip.write_all(b"nope").unwrap();
+            zip.finish().unwrap();
+        }
+
+        let result = extract_zip(
+            Utf8Path::from_path(zip_path.path()).unwrap(),
+            Utf8Path::from_path(rubies_dir.path()).unwrap(),
+            "ruby-3.4.1",
+            1,
+        );
+        assert!(matches!(result, Err(Error::DirectoryTraversalError(_))));
+    }
+
+    #[test]
+    fn test_extract_tarball_strips_single_root_for_jruby() {
+        use flate2::{Compression, write::GzEncoder};
+
+        let mut tar_data = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_data);
+
+            for dir in ["jruby-10.1.1.0/", "jruby-10.1.1.0/bin/"] {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(dir).unwrap();
+                header.set_size(0);
+                header.set_mode(0o755);
+                header.set_entry_type(tar::EntryType::Directory);
+                header.set_cksum();
+                builder.append(&header, std::io::empty()).unwrap();
+            }
+
+            let contents = b"#!/bin/sh\n";
+            let mut header = tar::Header::new_gnu();
+            header.set_path("jruby-10.1.1.0/bin/ruby").unwrap();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append(&header, &contents[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        {
+            let mut encoder = GzEncoder::new(&mut gz, Compression::default());
+            encoder.write_all(&tar_data).unwrap();
+            encoder.finish().unwrap();
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let rubies_dir = temp_dir.child("rubies");
+        rubies_dir.create_dir_all().unwrap();
+        let archive = temp_dir.child("jruby-bin-10.1.1.0.tar.gz");
+        archive.write_binary(&gz).unwrap();
+
+        extract_tarball(
+            Utf8Path::from_path(archive.path()).unwrap(),
+            Utf8Path::from_path(rubies_dir.path()).unwrap(),
+            &install_dir_name(&RubyEngine::JRuby, "10.1.1.0"),
+            tarball_strip_components(&RubyEngine::JRuby),
+        )
+        .unwrap();
+
+        let ruby_bin = rubies_dir
+            .child("jruby-10.1.1.0")
+            .child("bin")
+            .child("ruby");
+        assert!(
+            ruby_bin.exists(),
+            "jruby-10.1.1.0/bin/ruby should exist after extraction"
         );
     }
     #[test]
@@ -561,7 +846,7 @@ mod tests {
 
         let rubies_path = Utf8Path::from_path(rubies_dir.path()).unwrap();
         let zip_utf8_path = Utf8Path::from_path(zip_path.path()).unwrap();
-        extract_zip(zip_utf8_path, rubies_path, "3.4.1").unwrap();
+        extract_zip(zip_utf8_path, rubies_path, "ruby-3.4.1", 1).unwrap();
 
         let ruby_dir = rubies_dir.child("ruby-3.4.1");
         assert!(ruby_dir.exists(), "ruby-3.4.1 directory should exist");
@@ -595,7 +880,7 @@ mod tests {
         let rubies_path = Utf8Path::from_path(rubies_dir.path()).unwrap();
         let zip_utf8_path = Utf8Path::from_path(zip_path.path()).unwrap();
 
-        let result = extract_ruby_archive(zip_utf8_path, rubies_path, "3.4.1");
+        let result = extract_ruby_archive(zip_utf8_path, rubies_path, &RubyEngine::Ruby, "3.4.1");
         assert!(result.is_ok());
     }
 

--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -374,7 +374,14 @@ async fn fetch_url(url: &str, redirects: bool) -> Result<reqwest::Response> {
     Ok(request_builder.send().await?)
 }
 
-/// Must match what `Config::is_requested_ruby_installed_in_dir` looks for.
+/// Names the directory an install lands in, from the resolved version.
+///
+/// `Config::is_requested_ruby_installed_in_dir` builds its path from the *request*
+/// instead, so the two only line up when the request names a full version: `rv ruby
+/// install jruby-9.4` installs into `jruby-9.4.15.0` while the check looks for
+/// `jruby-9.4`. That mismatch is shared with CRuby, and its only effect is that the
+/// already-installed check in `install` misses and we re-extract over the same
+/// directory — never an install to the wrong place.
 fn install_dir_name(engine: &RubyEngine, version: &str) -> String {
     format!("{engine}-{version}")
 }
@@ -487,6 +494,13 @@ fn extract_tarball(
 
                 Component::Normal(part) => dst_file.push(part),
             }
+        }
+
+        // Nothing left after stripping the archive's root, so this entry *is* the
+        // install directory. Writing it would clobber the directory itself and make
+        // every later entry fail with a confusing IO error.
+        if dst_file == dst_dir {
+            continue;
         }
 
         // `Entry::unpack` won't create parents the way `Archive::unpack` does, and

--- a/crates/rv/src/commands/ruby/install.rs
+++ b/crates/rv/src/commands/ruby/install.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::io::Read as _;
 use std::path::{Component, PathBuf};
 use tokio::io::AsyncWriteExt;
-use tracing::{debug, info_span};
+use tracing::{debug, info_span, warn};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use rv_platform::HostPlatform;
@@ -75,6 +75,8 @@ pub(crate) async fn install(
         }
     };
 
+    warn_if_jvm_missing(&engine);
+
     let install_dir = match install_dir {
         Some(dir) => Utf8PathBuf::from(dir),
         None => match config.ruby_dirs.first() {
@@ -108,6 +110,21 @@ pub(crate) async fn install(
     println!("Installed {installed_version} to {}", install_dir.cyan());
 
     Ok(())
+}
+
+/// JRuby runs on the JVM, but rv doesn't install one. Without Java the install
+/// still succeeds while the ruby stays unusable, so say so before we spend the
+/// download rather than let `rv ruby find` come up empty later.
+fn warn_if_jvm_missing(engine: &RubyEngine) {
+    if engine != &RubyEngine::JRuby {
+        return;
+    }
+
+    if std::env::var_os("JAVA_HOME").is_some() || which::which("java").is_ok() {
+        return;
+    }
+
+    warn!("No JVM detected, but JRuby requires one. Install a JDK, or set JAVA_HOME.");
 }
 
 // downloads a remote ruby archive (tarball or zip)
@@ -418,9 +435,10 @@ fn extract_tarball(
         let mut entry = e?;
 
         // Paths over 100 bytes live in a preceding `././@LongLink` record. The tar
-        // crate only applies those under GNU magic, but JRuby's tarballs pair them
-        // with POSIX ustar magic, so the record surfaces here and the real entry
-        // arrives truncated. Apply the name ourselves.
+        // crate only applies those under GNU or ustar magic, but JRuby's tarballs
+        // write `ustar` magic with a zeroed version field, which is neither, so the
+        // record surfaces here and the real entry arrives with its name truncated to
+        // 100 bytes. Apply the name ourselves.
         match entry.header().entry_type() {
             tar::EntryType::GNULongName => {
                 let mut name = String::new();

--- a/crates/rv/src/config/ruby_fetcher.rs
+++ b/crates/rv/src/config/ruby_fetcher.rs
@@ -28,6 +28,12 @@ static PARSE_MAX_AGE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"max-age=(\d+
 static RUBYINSTALLER_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^rubyinstaller-(.+)-(\d+)-(x64|x86|arm)\.7z$").unwrap());
 
+/// Parses JRuby asset filenames: `jruby-bin-10.1.1.0.tar.gz` → version=`10.1.1.0`.
+static JRUBY_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^jruby-bin-(?P<version>[\d\.]+)\.tar\.gz$").unwrap());
+
+const JRUBY_CACHE_FILE: &str = "jruby.json";
+
 // Updated struct to hold ETag and calculated expiry time
 #[derive(Serialize, Deserialize, Debug)]
 struct CachedRelease {
@@ -72,25 +78,42 @@ impl Config {
             }
         };
 
-        let ((fetch_result, url), cache_file) = if host.is_windows() {
-            (
-                fetch_rubyinstaller2_rubies(&self.cache).await,
-                "rubyinstaller2.json",
-            )
-        } else {
-            (
-                fetch_available_rubies(&self.cache).await,
-                "available_rubies.json",
-            )
-        };
+        // Different repos, so fetch concurrently. Each is ETag-cached separately.
+        let cruby = async {
+            let ((fetch_result, url), cache_file) = if host.is_windows() {
+                (
+                    fetch_rubyinstaller2_rubies(&self.cache).await,
+                    "rubyinstaller2.json",
+                )
+            } else {
+                (
+                    fetch_available_rubies(&self.cache).await,
+                    "available_rubies.json",
+                )
+            };
 
-        let release = match fetch_result {
-            Ok(release) => release,
-            Err(e) => {
-                warn!("Could not fetch available Ruby versions: {}", e);
-                stale_cache_fallback(&self.cache, cache_file, &url)
+            match fetch_result {
+                Ok(release) => release,
+                Err(e) => {
+                    warn!("Could not fetch available Ruby versions: {}", e);
+                    stale_cache_fallback(&self.cache, cache_file, &url)
+                }
             }
         };
+
+        let jruby = async {
+            let (fetch_result, url) = fetch_jruby_rubies(&self.cache).await;
+
+            match fetch_result {
+                Ok(release) => release,
+                Err(e) => {
+                    warn!("Could not fetch available JRuby versions: {}", e);
+                    stale_cache_fallback(&self.cache, JRUBY_CACHE_FILE, &url)
+                }
+            }
+        };
+
+        let (release, jruby_release) = tokio::join!(cruby, jruby);
 
         let desired_os = host.os();
         let desired_arch = host.arch();
@@ -101,6 +124,15 @@ impl Config {
             .filter_map(|asset| ruby_from_asset(asset).ok())
             .filter(|ruby| ruby.os == desired_os && ruby.arch == desired_arch)
             .collect();
+
+        // JRuby's archives are universal, so there is no platform to filter on.
+        rubies.extend(
+            jruby_release
+                .assets
+                .iter()
+                .filter_map(|asset| jruby_from_asset(asset, &host).ok()),
+        );
+
         rubies.sort();
 
         debug!(
@@ -256,6 +288,64 @@ async fn fetch_rubyinstaller2_rubies(cache: &rv_cache::Cache) -> (Result<Release
     (release, url)
 }
 
+/// Fetches available JRuby versions from JRuby's own GitHub releases.
+async fn fetch_jruby_rubies(cache: &rv_cache::Cache) -> (Result<Release>, String) {
+    let env_var = "RV_JRUBY_LIST_URL";
+    let default_url = "https://api.github.com/repos/jruby/jruby/releases?per_page=100";
+    let url = url_for(env_var, default_url);
+    let release = fetch_cached_github_release(cache, JRUBY_CACHE_FILE, env_var, &url, |body| {
+        let releases: Vec<Release> = serde_json::from_slice(&body)?;
+        Ok(combine_jruby_releases(releases))
+    })
+    .await;
+    (release, url)
+}
+
+/// Normalizes JRuby's one-release-per-version format into a single synthetic Release,
+/// keeping only the binary tarballs and deduplicating by version.
+fn combine_jruby_releases(releases: Vec<Release>) -> Release {
+    use std::collections::HashMap;
+
+    let mut best: HashMap<String, Asset> = HashMap::new();
+
+    for release in &releases {
+        for asset in &release.assets {
+            if let Some(caps) = JRUBY_REGEX.captures(&asset.name) {
+                best.entry(caps["version"].to_string())
+                    .or_insert_with(|| asset.clone());
+            }
+        }
+    }
+
+    let mut assets: Vec<Asset> = best.into_values().collect();
+    assets.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Release {
+        name: "jruby-combined".to_string(),
+        assets,
+    }
+}
+
+/// Creates a Rubies info struct from a JRuby release asset. Archives are universal,
+/// so the entry takes the host's os/arch rather than anything from the filename.
+fn jruby_from_asset(asset: &Asset, host: &HostPlatform) -> Result<RemoteRuby> {
+    let caps = JRUBY_REGEX
+        .captures(&asset.name)
+        .ok_or_else(|| io::Error::other(format!("not a jruby asset: {}", asset.name)))?;
+
+    let version: rv_ruby::version::RubyVersion = format!("jruby-{}", &caps["version"]).parse()?;
+
+    let os = host.os();
+    let arch = host.arch();
+
+    Ok(RemoteRuby {
+        key: format!("{version}-{os}-{arch}"),
+        version,
+        arch: arch.to_string(),
+        os: os.to_string(),
+    })
+}
+
 /// Falls back to a stale cache file when a fresh fetch fails.
 fn stale_cache_fallback(cache: &rv_cache::Cache, cache_file: &str, url: &str) -> Release {
     let cache_key = cache_key_for(url, cache_file);
@@ -380,6 +470,7 @@ fn ruby_from_asset(asset: &Asset) -> Result<RemoteRuby> {
 mod tests {
     use super::*;
     use rv_ruby::version::RubyVersion;
+    use std::str::FromStr;
 
     #[test]
     fn test_parse_cache_header() {
@@ -580,6 +671,100 @@ mod tests {
         assert_eq!(ruby.version.patch, 8);
         assert_eq!(ruby.os, "windows");
         assert_eq!(ruby.arch, "aarch64");
+    }
+
+    #[test]
+    fn test_combine_jruby_releases_keeps_only_binary_tarballs() {
+        let releases = vec![make_release(
+            "JRuby 10.1.1.0",
+            &[
+                "jruby-bin-10.1.1.0.tar.gz", // the only one we want
+                "jruby-bin-10.1.1.0.zip",
+                "jruby-src-10.1.1.0.tar.gz",
+                "jruby-complete-10.1.1.0.jar",
+                "jruby-jars-10.1.1.0.gem",
+                "jruby_windows_x64_10_1_1_0.exe",
+            ],
+        )];
+
+        let result = combine_jruby_releases(releases);
+        let names: Vec<&str> = result.assets.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, ["jruby-bin-10.1.1.0.tar.gz"]);
+    }
+
+    #[test]
+    fn test_combine_jruby_releases_across_versions() {
+        let releases = vec![
+            make_release("JRuby 10.1.1.0", &["jruby-bin-10.1.1.0.tar.gz"]),
+            make_release("JRuby 9.4.15.0", &["jruby-bin-9.4.15.0.tar.gz"]),
+            make_release("JRuby 9.4.12.1", &["jruby-bin-9.4.12.1.tar.gz"]),
+        ];
+
+        let result = combine_jruby_releases(releases);
+        assert_eq!(result.assets.len(), 3);
+        assert_eq!(result.name, "jruby-combined");
+    }
+
+    #[test]
+    fn test_combine_jruby_releases_empty() {
+        let result = combine_jruby_releases(vec![]);
+        assert_eq!(result.assets.len(), 0);
+    }
+
+    #[test]
+    fn test_jruby_from_asset_is_universal() {
+        let asset = make_asset("jruby-bin-10.1.1.0.tar.gz");
+
+        let cases = [
+            ("aarch64-apple-darwin", "macos", "aarch64"),
+            ("x86_64-unknown-linux-gnu", "linux", "x86_64"),
+            ("x86_64-pc-windows-msvc", "windows", "x86_64"),
+        ];
+
+        for (triple, expected_os, expected_arch) in cases {
+            let host = HostPlatform::from_target_triple(triple).unwrap();
+            let ruby = jruby_from_asset(&asset, &host).unwrap();
+
+            assert_eq!(
+                ruby.version,
+                RubyVersion::from_str("jruby-10.1.1.0").unwrap()
+            );
+            assert_eq!(ruby.os, expected_os, "wrong os for {triple}");
+            assert_eq!(ruby.arch, expected_arch, "wrong arch for {triple}");
+            assert_eq!(
+                ruby.key,
+                format!("jruby-10.1.1.0-{expected_os}-{expected_arch}")
+            );
+        }
+    }
+
+    #[test]
+    fn test_jruby_from_asset_parses_four_segment_versions() {
+        let host = HostPlatform::from_target_triple("aarch64-apple-darwin").unwrap();
+        let asset = make_asset("jruby-bin-9.4.12.1.tar.gz");
+
+        let ruby = jruby_from_asset(&asset, &host).unwrap();
+        assert_eq!(ruby.version.engine, rv_ruby::engine::RubyEngine::JRuby);
+        assert_eq!(ruby.version.major, 9);
+        assert_eq!(ruby.version.minor, 4);
+        assert_eq!(ruby.version.patch, 12);
+        assert_eq!(ruby.version.tiny, Some(1));
+    }
+
+    #[test]
+    fn test_jruby_from_asset_rejects_non_jruby_assets() {
+        let host = HostPlatform::from_target_triple("aarch64-apple-darwin").unwrap();
+
+        for name in [
+            "ruby-3.4.1.arm64_sonoma.tar.gz",
+            "jruby-src-10.1.1.0.tar.gz",
+            "jruby-complete-10.1.1.0.jar",
+        ] {
+            assert!(
+                jruby_from_asset(&make_asset(name), &host).is_err(),
+                "{name} should not parse as a JRuby install archive"
+            );
+        }
     }
 
     #[test]

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -489,8 +489,17 @@ impl RvTest {
     /// Append a file whose path exceeds tar's 100-byte name field, using a GNU
     /// long-name record with POSIX ustar magic, as JRuby's tarballs do.
     fn add_long_name_file(builder: &mut Builder<&mut Vec<u8>>, path: &str, content: &str) {
+        // Write the 100-byte name field directly rather than via `set_path`, which
+        // normalizes paths per-platform. This test is about exact tar bytes.
+        fn set_raw_name(header: &mut tar::Header, name: &str) {
+            let field = &mut header.as_old_mut().name;
+            let bytes = name.as_bytes();
+            let len = bytes.len().min(field.len());
+            field[..len].copy_from_slice(&bytes[..len]);
+        }
+
         let mut name_header = tar::Header::new_ustar();
-        name_header.set_path("././@LongLink").unwrap();
+        set_raw_name(&mut name_header, "././@LongLink");
         name_header.set_size(path.len() as u64 + 1);
         name_header.set_mode(0o644);
         name_header.set_entry_type(tar::EntryType::GNULongName);
@@ -500,9 +509,8 @@ impl RvTest {
         builder.append(&name_header, &name_data[..]).unwrap();
 
         // The real entry carries the name truncated to the 100-byte field.
-        let truncated: String = path.chars().take(100).collect();
         let mut header = tar::Header::new_ustar();
-        header.set_path(&truncated).unwrap();
+        set_raw_name(&mut header, path);
         header.set_size(content.len() as u64);
         header.set_mode(0o644);
         header.set_cksum();
@@ -715,12 +723,12 @@ impl RvTest {
     }
 
     #[cfg(unix)]
-    fn ruby_executable_name(&self) -> &str {
+    pub fn ruby_executable_name(&self) -> &str {
         "ruby"
     }
 
     #[cfg(windows)]
-    fn ruby_executable_name(&self) -> &str {
+    pub fn ruby_executable_name(&self) -> &str {
         "ruby.cmd"
     }
 

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -236,6 +236,47 @@ impl RvTest {
             .create()
     }
 
+    /// Mocks JRuby's /releases API endpoint. Takes no platform: archives are universal.
+    pub fn mock_jruby_releases(&mut self, versions: Vec<&str>) -> Mock {
+        use indoc::formatdoc;
+
+        let releases = versions
+            .into_iter()
+            .map(|v| {
+                formatdoc!(
+                    r#"
+            {{
+                "name": "JRuby {v}",
+                "assets": [
+                    {{
+                        "name": "jruby-bin-{v}.tar.gz",
+                        "browser_download_url": "http://..."
+                    }},
+                    {{
+                        "name": "jruby-src-{v}.tar.gz",
+                        "browser_download_url": "http://..."
+                    }}
+                ]
+            }}"#
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",\n    ");
+
+        let body = format!("[{releases}]");
+
+        self.env.insert(
+            "RV_JRUBY_LIST_URL".into(),
+            format!("{}/{}", self.server_url(), "repos/jruby/jruby/releases"),
+        );
+
+        self.mock_request("GET", "repos/jruby/jruby/releases")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create()
+    }
+
     /// Mocks the rv-ruby /releases endpoint with assets for all NON-WINDOWS platforms.
     ///
     /// Windows uses a separate endpoint (RubyInstaller2), so Windows assets
@@ -319,6 +360,13 @@ impl RvTest {
     pub fn mock_ruby_download(&mut self, version: &str) -> Mock {
         let path = self.ruby_tarball_download_path(version);
         let content = self.create_mock_tarball(version);
+        self.mock_tarball_download(&path, &content)
+    }
+
+    /// Mock a JRuby tarball download for testing
+    pub fn mock_jruby_download(&mut self, version: &str) -> Mock {
+        let path = self.jruby_tarball_download_path(version);
+        let content = self.create_mock_jruby_tarball(version);
         self.mock_tarball_download(&path, &content)
     }
 
@@ -406,6 +454,61 @@ impl RvTest {
         Self::gzip_tar(archive_data)
     }
 
+    /// Build a mock JRuby archive: a single root, plus a long path stored the way
+    /// JRuby's real tarballs store them (see `extract_tarball`).
+    pub fn create_mock_jruby_tarball(&self, version: &str) -> Vec<u8> {
+        let mut archive_data = Vec::new();
+        {
+            let mut builder = Builder::new(&mut archive_data);
+
+            let root = format!("jruby-{version}/");
+            Self::add_dir(&mut builder, &root);
+
+            let bin_dir = format!("{root}bin/");
+            Self::add_dir(&mut builder, &bin_dir);
+
+            let ruby_bin = format!("{bin_dir}{}", self.ruby_executable_name());
+            let ruby_content = &self.ruby_mock_script("jruby", version);
+            Self::add_executable(&mut builder, &ruby_bin, ruby_content);
+
+            let long_path = format!(
+                "{root}lib/ruby/stdlib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb"
+            );
+            assert!(
+                long_path.len() > 100,
+                "test path should need a long-name record"
+            );
+            Self::add_long_name_file(&mut builder, &long_path, "# long path\n");
+
+            builder.finish().unwrap();
+        }
+
+        Self::gzip_tar(archive_data)
+    }
+
+    /// Append a file whose path exceeds tar's 100-byte name field, using a GNU
+    /// long-name record with POSIX ustar magic, as JRuby's tarballs do.
+    fn add_long_name_file(builder: &mut Builder<&mut Vec<u8>>, path: &str, content: &str) {
+        let mut name_header = tar::Header::new_ustar();
+        name_header.set_path("././@LongLink").unwrap();
+        name_header.set_size(path.len() as u64 + 1);
+        name_header.set_mode(0o644);
+        name_header.set_entry_type(tar::EntryType::GNULongName);
+        name_header.set_cksum();
+        let mut name_data = path.as_bytes().to_vec();
+        name_data.push(0);
+        builder.append(&name_header, &name_data[..]).unwrap();
+
+        // The real entry carries the name truncated to the 100-byte field.
+        let truncated: String = path.chars().take(100).collect();
+        let mut header = tar::Header::new_ustar();
+        header.set_path(&truncated).unwrap();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, content.as_bytes()).unwrap();
+    }
+
     fn gzip_tar(tar_data: Vec<u8>) -> Vec<u8> {
         use flate2::Compression;
         use flate2::write::GzEncoder;
@@ -438,6 +541,18 @@ impl RvTest {
         header.set_mode(0o755);
         header.set_cksum();
         builder.append(&header, content.as_bytes()).unwrap();
+    }
+
+    pub fn jruby_tarball_url(&self, version: &str) -> String {
+        format!(
+            "{}/{}",
+            self.server_url(),
+            self.jruby_tarball_download_path(version)
+        )
+    }
+
+    pub fn jruby_tarball_download_path(&self, version: &str) -> String {
+        format!("latest/download/{version}/jruby-bin-{version}.tar.gz")
     }
 
     pub fn ruby_tarball_url(&self, version: &str) -> String {
@@ -581,6 +696,8 @@ impl RvTest {
                 "repos/oneclick/rubyinstaller2/releases"
             ),
         );
+        // `-` means "make no request"; mock_jruby_releases opts a test back in.
+        self.env.insert("RV_JRUBY_LIST_URL".into(), "-".into());
 
         // Override the rubies directory so rv looks in the test temp dir.
         // On Windows, etcetera resolves data_dir via the Win32 SHGetKnownFolderPath

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -486,6 +486,35 @@ impl RvTest {
         Self::gzip_tar(archive_data)
     }
 
+    /// Build a mock archive that leads with a file at the archive root, so stripping
+    /// the root components leaves nothing and the entry would otherwise be written
+    /// over the install directory itself (see `extract_tarball`).
+    pub fn create_mock_tarball_with_root_file(&self, version: &str) -> Vec<u8> {
+        let mut archive_data = Vec::new();
+        {
+            let mut builder = Builder::new(&mut archive_data);
+
+            Self::add_executable(&mut builder, "README", "# at the archive root\n");
+
+            let root = format!("rv-ruby@{version}/");
+            Self::add_dir(&mut builder, &root);
+
+            let subroot = format!("{root}{version}/");
+            Self::add_dir(&mut builder, &subroot);
+
+            let bin_dir = format!("{subroot}bin/");
+            Self::add_dir(&mut builder, &bin_dir);
+
+            let ruby_bin = format!("{bin_dir}{}", self.ruby_executable_name());
+            let ruby_content = &self.ruby_mock_script("ruby", version);
+            Self::add_executable(&mut builder, &ruby_bin, ruby_content);
+
+            builder.finish().unwrap();
+        }
+
+        Self::gzip_tar(archive_data)
+    }
+
     /// Append a file whose path exceeds tar's 100-byte name field, using a GNU
     /// long-name record with `ustar` magic but a zeroed version field, as JRuby's
     /// tarballs do. The tar crate treats those headers as neither ustar nor GNU, so

--- a/crates/rv/tests/integration_tests/common.rs
+++ b/crates/rv/tests/integration_tests/common.rs
@@ -487,7 +487,9 @@ impl RvTest {
     }
 
     /// Append a file whose path exceeds tar's 100-byte name field, using a GNU
-    /// long-name record with POSIX ustar magic, as JRuby's tarballs do.
+    /// long-name record with `ustar` magic but a zeroed version field, as JRuby's
+    /// tarballs do. The tar crate treats those headers as neither ustar nor GNU, so
+    /// it leaves the record for us (see `extract_tarball`).
     fn add_long_name_file(builder: &mut Builder<&mut Vec<u8>>, path: &str, content: &str) {
         // Write the 100-byte name field directly rather than via `set_path`, which
         // normalizes paths per-platform. This test is about exact tar bytes.
@@ -503,6 +505,9 @@ impl RvTest {
         name_header.set_size(path.len() as u64 + 1);
         name_header.set_mode(0o644);
         name_header.set_entry_type(tar::EntryType::GNULongName);
+        // JRuby's headers carry `ustar` magic with a zeroed version, which the tar
+        // crate does not recognize as ustar, so it does not apply the long name.
+        name_header.as_ustar_mut().unwrap().version = *b"\0\0";
         name_header.set_cksum();
         let mut name_data = path.as_bytes().to_vec();
         name_data.push(0);
@@ -513,6 +518,7 @@ impl RvTest {
         set_raw_name(&mut header, path);
         header.set_size(content.len() as u64);
         header.set_mode(0o644);
+        header.as_ustar_mut().unwrap().version = *b"\0\0";
         header.set_cksum();
         builder.append(&header, content.as_bytes()).unwrap();
     }

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -112,6 +112,29 @@ fn test_ruby_install_from_tarball() {
 }
 
 #[test]
+fn test_ruby_install_from_tarball_with_file_at_archive_root() {
+    let mut test = RvTest::new();
+
+    let tarball_content = test.create_mock_tarball_with_root_file("3.4.5");
+    let tarball_file = test.mock_tarball_on_disk("3.4.5", tarball_content);
+
+    let output = test.rv(&[
+        "ruby",
+        "install",
+        "--tarball-path",
+        tarball_file.as_str(),
+        "3.4.5",
+    ]);
+
+    output.assert_success();
+
+    // The root file is skipped rather than written over the install directory, so
+    // the entries after it still land where they belong.
+    let output = test.rv(&["run", "ruby"]);
+    output.assert_stdout_contains("ruby\n3.4.5");
+}
+
+#[test]
 fn test_ruby_install_from_tarball_with_files_falling_outside_root() {
     let test = RvTest::new();
 

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -438,14 +438,17 @@ fn test_jruby_install() {
 
     // The directory has to be engine-qualified, or rv won't find it again.
     let install_dir = test.rubies_dir().join("jruby-10.1.1.0");
-    assert!(
-        install_dir.join("bin").join("ruby").exists(),
-        "jruby-10.1.1.0/bin/ruby should exist"
-    );
+    let ruby_bin = install_dir.join("bin").join(test.ruby_executable_name());
+    assert!(ruby_bin.exists(), "{ruby_bin} should exist");
 
     // Needs the long-name record applied, or it lands truncated to 100 bytes.
     let long_path = install_dir
-        .join("lib/ruby/stdlib/did_you_mean/spell_checkers/name_error_checkers")
+        .join("lib")
+        .join("ruby")
+        .join("stdlib")
+        .join("did_you_mean")
+        .join("spell_checkers")
+        .join("name_error_checkers")
         .join("variable_name_checker.rb");
     assert!(
         long_path.exists(),
@@ -488,7 +491,7 @@ fn test_jruby_install_resolves_incomplete_request() {
         test.rubies_dir()
             .join("jruby-9.4.15.0")
             .join("bin")
-            .join("ruby")
+            .join(test.ruby_executable_name())
             .exists()
     );
 }

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -472,6 +472,47 @@ fn test_jruby_install() {
 }
 
 #[test]
+fn test_jruby_install_warns_when_no_jvm_is_present() {
+    let mut test = RvTest::new();
+
+    // The test environment is cleared, so there is no JAVA_HOME and no PATH
+    // to find `java` on.
+    let jruby_mock = test.mock_jruby_download("10.1.1.0").create();
+    let mock = test.mock_jruby_releases(["10.1.1.0"].to_vec());
+
+    let output = test.rv(&["ruby", "install", "jruby-10.1.1.0"]);
+
+    jruby_mock.assert();
+    output.assert_success();
+    output.assert_stderr_contains("No JVM detected");
+
+    drop(mock);
+}
+
+#[test]
+fn test_jruby_install_does_not_warn_when_java_home_is_set() {
+    let mut test = RvTest::new();
+
+    test.env
+        .insert("JAVA_HOME".into(), "/usr/lib/jvm/whatever".into());
+
+    let jruby_mock = test.mock_jruby_download("10.1.1.0").create();
+    let mock = test.mock_jruby_releases(["10.1.1.0"].to_vec());
+
+    let output = test.rv(&["ruby", "install", "jruby-10.1.1.0"]);
+
+    jruby_mock.assert();
+    output.assert_success();
+    assert!(
+        !output.stderr().contains("No JVM detected"),
+        "expected no JVM warning, got:\n{}",
+        output.stderr()
+    );
+
+    drop(mock);
+}
+
+#[test]
 fn test_jruby_install_resolves_incomplete_request() {
     let mut test = RvTest::new();
 

--- a/crates/rv/tests/integration_tests/ruby/install_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/install_test.rs
@@ -419,3 +419,94 @@ fn test_ruby_install_with_dev() {
         .join(format!("{}.tar.gz", cache_key));
     assert!(tarball_path.exists(), "Tarball should be cached");
 }
+
+#[test]
+fn test_jruby_install() {
+    let mut test = RvTest::new();
+
+    let jruby_mock = test.mock_jruby_download("10.1.1.0").create();
+    let cache_dir = test.enable_cache();
+    let mock = test.mock_jruby_releases(["10.1.1.0"].to_vec());
+
+    let output = test.rv(&["ruby", "install", "jruby-10.1.1.0"]);
+
+    jruby_mock.assert();
+    output.assert_success();
+    output.assert_stdout_contains(
+        "Installed jruby version 10.1.1.0 to /tmp/home/.local/share/rv/rubies",
+    );
+
+    // The directory has to be engine-qualified, or rv won't find it again.
+    let install_dir = test.rubies_dir().join("jruby-10.1.1.0");
+    assert!(
+        install_dir.join("bin").join("ruby").exists(),
+        "jruby-10.1.1.0/bin/ruby should exist"
+    );
+
+    // Needs the long-name record applied, or it lands truncated to 100 bytes.
+    let long_path = install_dir
+        .join("lib/ruby/stdlib/did_you_mean/spell_checkers/name_error_checkers")
+        .join("variable_name_checker.rb");
+    assert!(
+        long_path.exists(),
+        "long path should be restored in full, got: {:?}",
+        fs::read_dir(
+            install_dir.join("lib/ruby/stdlib/did_you_mean/spell_checkers/name_error_checkers")
+        )
+        .map(|d| d
+            .filter_map(|e| e.ok().map(|e| e.file_name()))
+            .collect::<Vec<_>>())
+    );
+
+    let cache_key = rv_cache::cache_digest(test.jruby_tarball_url("10.1.1.0"));
+    let tarball_path = cache_dir
+        .join("ruby-v0")
+        .join("tarballs")
+        .join(format!("{}.tar.gz", cache_key));
+    assert!(tarball_path.exists(), "Tarball should be cached");
+
+    drop(mock);
+}
+
+#[test]
+fn test_jruby_install_resolves_incomplete_request() {
+    let mut test = RvTest::new();
+
+    let jruby_mock = test.mock_jruby_download("9.4.15.0").create();
+    test.enable_cache();
+    let mock = test.mock_jruby_releases(["9.4.12.1", "9.4.15.0", "10.1.1.0"].to_vec());
+
+    // Must pick the newest 9.4.x, not the newest JRuby overall.
+    let output = test.rv(&["ruby", "install", "jruby-9.4"]);
+
+    jruby_mock.assert();
+    mock.assert();
+    output.assert_success();
+    output.assert_stdout_contains("Installed jruby version 9.4.15.0");
+
+    assert!(
+        test.rubies_dir()
+            .join("jruby-9.4.15.0")
+            .join("bin")
+            .join("ruby")
+            .exists()
+    );
+}
+
+#[test]
+fn test_ruby_install_is_unaffected_by_jruby_support() {
+    let mut test = RvTest::new();
+
+    let ruby_mock = test.mock_ruby_download("3.4.5").create();
+    test.enable_cache();
+    // Fully specified: resolves without the releases list, so this mock isn't asserted.
+    let _mock = test.mock_releases(["3.4.5"].to_vec());
+
+    let output = test.rv(&["ruby", "install", "3.4.5"]);
+
+    ruby_mock.assert();
+    output.assert_success();
+    output.assert_stdout_contains("Installed Ruby version 3.4.5");
+
+    assert!(test.rubies_dir().join("ruby-3.4.5").exists());
+}

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -94,7 +94,7 @@ rv combines several functions that have previously been separate tools:
 - [x] MRI 3.4
 - [x] MRI 3.3
 - [x] MRI 3.2
-- [ ] JRuby 10
+- [x] JRuby 10
 - [ ] TruffleRuby 24
 
 ### EOL interpreters (maybe)


### PR DESCRIPTION
👋 Hi hi!

I got nerd-sniped into seeing how hard JRuby Support would be.

I'm not a rust programmer, so forgive me for I have leaned into LLMs where I have lacked. That said, I stand behind this code and it looks OK to my untrained rust eye, but let me know where I can improve at! Happy to change it to the rust-way. (also if it's not something y'all are comfortable with taking, we can close too!)

I wanted JRuby for some work I'm doing with Hanami down the road and since I use `rv` I didn't want to pollute my system with other version managers .

Two things of note-worthyness:
- It uses the list of jruby releases from the GitHub. This semi matched the Ruby stuff, but it is another set of API calls on an unauthenticated GitHub calls potentially halving them. Happy to discuss where this should live or move to etc to make it easier?
- I did not have a windows box close to test this against 😢 I can if needed I just need to spin that stuff up! 


❤️ thanks for the best quickest-mostest version manager

