### PR TITLE
Add AI policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,51 @@
+**`rv` is here for humans.** We welcome your contributions, and you are welcome to use whatever tools you like, but we require all contributions to be **human-first**.
+
+If you wish to use an AI tool for assistance, please respect the policy below.
+
+## Policy
+
+- As a contributor, you are always the author and fully accountable for your contributions.
+- You must carefully read and review all LLM-generated code or text before asking maintainers to review it. This includes PR descriptions, where we want to hear your personal voice rather than an unfiltered AI summary.
+- You should be transparent and make note if your contribution contains substantial amounts of tool-generated content.
+- You should be confident that your contribution is high enough quality to merit a maintainer's time for review. You should be able to answer questions about your work during review.
+- You are responsible for ensuring you have the legal right to make your contribution under our license, and that your contribution does not violate the intellectual property rights of any third party.
+
+This policy includes, but is not limited to, the following kinds of contributions:
+
+- Code, usually in the form of a pull request
+- Feature proposals
+- Issues or security vulnerabilities
+- Comments and feedback on issues or pull requests
+- Posts in our community discussion spaces
+
+We aspire to be a welcoming community that helps new contributors grow their expertise. If you're getting started, we suggest you build your confidence by starting with small changes you can fully understand. Your learning will come from taking small steps, getting feedback, and iterating. Passing maintainer feedback to an LLM won't help anyone grow, nor will it sustain our community.
+
+## Agents not allowed
+
+This policy disallows agents that take action in our spaces without human approval, such as the GitHub Copilot or Claude agents. Similarly, automated review tools that publish comments without human review are not allowed.
+
+We will not commit any material to our repos specifically in support of agent usage. If you wish to add documentation to make contributions easier, please write it for other humans.
+
+## Rationale
+
+This policy is for both our community and maintainers.
+
+For our community, we want you to trust that every change to our code sees genuine, human attention and care.
+
+For our maintainers, we want to ensure your limited time and energy is spent reviewing valuable, constructive contributions, and helping other human contributors grow their knowledge of our tools.
+
+## Handling violations
+
+If a maintainer judges that a contribution doesn't comply with this policy, they should paste the following:
+
+> This PR does not appear to comply with our policy on tool-generated content. Please explain why this PR is valuable enough to warrant our review. See our AI contribution policy for more: https://rv.dev/ai-policy
+
+As a contributor, you can make your change more valuable by inserting yourself in the process: review and understand the code, and explain it in your own words. Consider ways to reduce the size and complexity of your change, or ways to increase its usefulness to our community.
+
+If a contributor fails to meaningfully engage with this policy and improve their change, maintainers should lock the conversation and close the PR.
+
+If a contribution comes directly from an agent, it should be locked and closed immediately.
+
+## References
+
+This policy is adapted from [Hanakai's AI Policy](https://hanakai.org/ai-policy), which is in turn informed by [LLVM's AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) and [Mastodon's AI Contribution Policy](https://github.com/mastodon/.github/blob/main/AI_POLICY.md).


### PR DESCRIPTION
Based on [the Hanakai AI policy](https://hanakai.org/ai-policy), this proposed policy focuses on our desire to build tools for humans, with humans.
