### PR TITLE
Do proper probing for shared Rubies

### DIFF
--- a/crates/rv-ruby/src/lib.rs
+++ b/crates/rv-ruby/src/lib.rs
@@ -310,7 +310,7 @@ fn extract_ruby_info(ruby_bin: &Utf8PathBuf) -> Result<Ruby, RubyError> {
         puts(Gem::Platform.local.to_s)
         puts(Object.const_defined?(:RbConfig) && RbConfig::CONFIG['host_cpu'] ? RbConfig::CONFIG['host_cpu'] : 'unknown')
         puts(Object.const_defined?(:RbConfig) && RbConfig::CONFIG['host_os'] ? RbConfig::CONFIG['host_os'] : 'unknown')
-        puts(Object.const_defined?(:RbConfig) && RbConfig::CONFIG['ENABLE_SHARED'] ? RbConfig::CONFIG['ENABLED_SHARED'] : 'no')
+        puts(Object.const_defined?(:RbConfig) && RbConfig::CONFIG['ENABLE_SHARED'] ? RbConfig::CONFIG['ENABLE_SHARED'] : 'no')
         puts(begin; Gem.default_dir; rescue ScriptError, NoMethodError; end)
         puts(Object.const_defined?(:RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : '')
     "#;
@@ -383,7 +383,7 @@ fn extract_ruby_info(ruby_bin: &Utf8PathBuf) -> Result<Ruby, RubyError> {
         os,
         gem_root,
         managed: false,
-        enable_shared: enable_shared == "no",
+        enable_shared: enable_shared != "no",
         rubygems_platform: ruby_platform.to_string(),
         // path and symlink are replaced in the caller
         path: Default::default(),

--- a/crates/rv/tests/integration_tests/ruby/list_test.rs
+++ b/crates/rv/tests/integration_tests/ruby/list_test.rs
@@ -102,7 +102,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -116,7 +116,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -130,7 +130,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": true
@@ -152,7 +152,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -166,7 +166,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -180,7 +180,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -194,7 +194,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": true
@@ -220,7 +220,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -234,7 +234,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -248,7 +248,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": false
@@ -262,7 +262,7 @@ fn test_ruby_list_multiple_matching_rubies() {
           "arch": "aarch64",
           "os": "macos",
           "gem_root": null,
-          "enable_shared": true,
+          "enable_shared": false,
           "rubygems_platform": "aarch64-darwin23"
         },
         "active": true

--- a/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_json_output_with_rubies.snap
+++ b/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_json_output_with_rubies.snap
@@ -12,7 +12,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": false
@@ -26,7 +26,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": true

--- a/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_text_output_with_rubies.snap
+++ b/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_text_output_with_rubies.snap
@@ -12,7 +12,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": false
@@ -26,7 +26,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": true

--- a/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_merges_both_lists.snap
+++ b/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_merges_both_lists.snap
@@ -12,7 +12,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": true

--- a/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_remotes_keep_only_latest_patch.snap
+++ b/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_remotes_keep_only_latest_patch.snap
@@ -12,7 +12,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": true

--- a/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_sorts_properly.snap
+++ b/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_sorts_properly.snap
@@ -12,7 +12,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": true

--- a/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_with_same_minor_lists_all_versions.snap
+++ b/crates/rv/tests/integration_tests/ruby/snapshots/integration_tests__ruby__list_test__ruby_list_with_available_and_installed_with_same_minor_lists_all_versions.snap
@@ -12,7 +12,7 @@ expression: output.normalized_stdout()
       "arch": "aarch64",
       "os": "macos",
       "gem_root": null,
-      "enable_shared": true,
+      "enable_shared": false,
       "rubygems_platform": "aarch64-darwin23"
     },
     "active": true


### PR DESCRIPTION
This follows the nose of the report in https://github.com/spinel-coop/rv/issues/721 to begin the work of properly detecting shared Rubies. This is mainly a update to the script; going to do more smoke testing to confirm it works as expected.

Noticed that `rv ruby install` _only_ does the static installs so I'd need to test this on a MacBook (for the system Ruby) or with a system-built Ruby (on my host Debian machine).